### PR TITLE
perf: parallelize CSV loader (rayon + streaming unzip→parse)

### DIFF
--- a/crates/gtfs_model/src/lib.rs
+++ b/crates/gtfs_model/src/lib.rs
@@ -30,6 +30,20 @@ thread_local! {
     static RESOLVER_HOOK: RefCell<Option<ResolverHook>> = RefCell::new(None);
 }
 
+/// Restores the previous thread-local interner when dropped.
+#[must_use = "the scoped interner is restored when the guard is dropped"]
+pub struct ThreadLocalInternerGuard {
+    previous: Option<InternerHook>,
+}
+
+impl Drop for ThreadLocalInternerGuard {
+    fn drop(&mut self) {
+        INTERNER_HOOK.with(|hook| {
+            *hook.borrow_mut() = self.previous.take();
+        });
+    }
+}
+
 pub fn set_thread_local_interner<F>(f: F)
 where
     F: Fn(&str) -> StringId + 'static,
@@ -37,6 +51,15 @@ where
     INTERNER_HOOK.with(|hook| {
         *hook.borrow_mut() = Some(Box::new(f));
     });
+}
+
+pub fn set_thread_local_interner_scoped<F>(f: F) -> ThreadLocalInternerGuard
+where
+    F: Fn(&str) -> StringId + 'static,
+{
+    let previous = INTERNER_HOOK.with(|hook| hook.borrow_mut().take());
+    set_thread_local_interner(f);
+    ThreadLocalInternerGuard { previous }
 }
 
 pub fn set_thread_local_resolver<F>(f: F)
@@ -1182,6 +1205,30 @@ pub struct Translation {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn intern_with_current_hook(value: &str) -> StringId {
+        INTERNER_HOOK.with(|hook| {
+            hook.borrow()
+                .as_ref()
+                .map(|intern| intern(value))
+                .unwrap_or_default()
+        })
+    }
+
+    #[test]
+    fn scoped_interner_restores_previous_hook() {
+        clear_thread_local_hooks();
+        set_thread_local_interner(|_| StringId(1));
+        assert_eq!(intern_with_current_hook("outer"), StringId(1));
+
+        {
+            let _guard = set_thread_local_interner_scoped(|_| StringId(2));
+            assert_eq!(intern_with_current_hook("inner"), StringId(2));
+        }
+
+        assert_eq!(intern_with_current_hook("outer"), StringId(1));
+        clear_thread_local_hooks();
+    }
 
     #[test]
     fn parses_gtfs_date() {

--- a/crates/gtfs_validator_core/src/csv_reader.rs
+++ b/crates/gtfs_validator_core/src/csv_reader.rs
@@ -138,7 +138,11 @@ where
     ))
 }
 
-fn map_csv_error(file: &str, headers: Option<&StringRecord>, err: csv::Error) -> CsvParseError {
+pub(crate) fn map_csv_error(
+    file: &str,
+    headers: Option<&StringRecord>,
+    err: csv::Error,
+) -> CsvParseError {
     let position = err.position();
     let row = position.map(|pos| pos.line());
     let field_index = match err.kind() {
@@ -166,7 +170,20 @@ fn map_csv_error(file: &str, headers: Option<&StringRecord>, err: csv::Error) ->
     }
 }
 
-fn skip_utf8_bom<R: BufRead>(reader: &mut R) -> std::io::Result<()> {
+pub(crate) fn map_io_error(file: &str, err: std::io::Error) -> CsvParseError {
+    CsvParseError {
+        file: file.to_string(),
+        row: None,
+        field: None,
+        message: err.to_string(),
+        char_index: None,
+        column_index: None,
+        line_index: None,
+        parsed_content: None,
+    }
+}
+
+pub(crate) fn skip_utf8_bom<R: BufRead>(reader: &mut R) -> std::io::Result<()> {
     let buf = reader.fill_buf()?;
     if buf.starts_with(&[0xEF, 0xBB, 0xBF]) {
         reader.consume(3);
@@ -176,38 +193,31 @@ fn skip_utf8_bom<R: BufRead>(reader: &mut R) -> std::io::Result<()> {
 
 /// Parallel version of CSV parsing using rayon.
 ///
-/// The CSV crate handles record boundary detection sequentially (fast),
-/// while Serde deserialization is parallelized across a thread pool (CPU-intensive).
-/// Results are sorted by index to preserve original file order.
+/// Record boundary detection runs sequentially (the csv crate must scan the
+/// buffer in order to honor quoted fields), but the expensive work — UTF-8
+/// validation, field trimming, serde deserialization and per-row validation —
+/// is parallelized across the rayon thread pool in row chunks.
 ///
-/// The `interner_setup` closure is called on each worker thread before deserialization
-/// to set up thread-local hooks (e.g., StringId interner) that are needed during serde deserialization.
+/// `pool` is the shared string interner. Each worker thread installs a
+/// thread-local interner hook (read by `StringId`'s `Deserialize` impl) and
+/// re-applies the captured validation context (read by the row validator)
+/// before processing its chunk.
 #[cfg(feature = "parallel")]
-pub fn read_csv_from_reader_parallel<T, R, V, I>(
+pub fn read_csv_from_reader_parallel<T, R, V>(
     reader: R,
     file_name: impl Into<String>,
     validator: V,
-    interner_setup: I,
+    pool: &crate::StringPool,
 ) -> Result<(CsvTable<T>, Vec<CsvParseError>, Vec<ValidationNotice>), CsvParseError>
 where
     T: DeserializeOwned + Send,
     R: Read,
-    V: Fn(&csv::StringRecord, u64) -> Vec<ValidationNotice> + Sync + Send,
-    I: Fn() + Sync + Send,
+    V: Fn(&csv::StringRecord, u64) -> Vec<ValidationNotice> + Sync,
 {
     let file = file_name.into();
     let mut buf_reader = BufReader::new(reader);
     if let Err(err) = skip_utf8_bom(&mut buf_reader) {
-        return Err(CsvParseError {
-            file,
-            row: None,
-            field: None,
-            message: err.to_string(),
-            char_index: None,
-            column_index: None,
-            line_index: None,
-            parsed_content: None,
-        });
+        return Err(map_io_error(&file, err));
     }
 
     let mut csv_reader = ReaderBuilder::new()
@@ -224,22 +234,20 @@ where
         .iter()
         .map(|value| value.trim().to_string())
         .collect();
-    let byte_headers = csv::ByteRecord::from(headers_record.clone());
 
-    // Collect byte records with their line numbers sequentially
-    // The csv crate's iterator handles record boundary detection
-    let mut raw_records: Vec<(usize, u64, csv::ByteRecord)> = Vec::new();
+    // Collect byte records with their line numbers sequentially.
+    // The csv crate's iterator handles record boundary detection (quote-aware).
+    let mut raw_records: Vec<(u64, csv::ByteRecord)> = Vec::new();
     let mut scan_errors: Vec<CsvParseError> = Vec::new();
 
     for (index, result) in csv_reader.byte_records().enumerate() {
         match result {
             Ok(record) => {
-                // Determine line number from position if available, otherwise fallback to estimation
                 let line_number = record
                     .position()
                     .map(|p| p.line())
                     .unwrap_or((index + 2) as u64);
-                raw_records.push((index, line_number, record));
+                raw_records.push((line_number, record));
             }
             Err(err) => {
                 scan_errors.push(map_csv_error(&file, Some(&headers_record), err));
@@ -247,78 +255,24 @@ where
         }
     }
 
-    // Parallel deserialization using rayon
-    let file_ref = &file;
-    let headers_ref = &headers_record;
-    let _byte_headers_ref = &byte_headers;
-    let validator_ref = &validator;
-    let _interner_setup_ref = &interner_setup;
+    // Capture the validation context so each worker can re-apply it.
+    let ctx = crate::validation_context::ValidationContextState::capture();
 
-    let mut results: Vec<(usize, u64, Result<T, CsvParseError>, Vec<ValidationNotice>)> =
-        raw_records
-            .into_iter() // Use iter() instead of par_iter() to keep deserialization on caller thread (which has interner hook)
-            .map(|(index, line_number, record)| {
-                // The interner hook is already set on this thread (set by ParallelLoader::load in feed.rs)
-                // No need to call interner_setup_ref() since we're on the same thread
+    let processed = deserialize_validate_records::<T, _>(
+        raw_records,
+        &headers_record,
+        &file,
+        &validator,
+        pool,
+        &ctx,
+    );
 
-                let mut notices = Vec::new();
-                // Explicitly convert to StringRecord for validation (checks UTF-8)
-                match csv::StringRecord::from_byte_record(record.clone()) {
-                    Ok(string_record) => {
-                        // string_record is untrimmed (except headers logic).
-                        // Validate untrimmed data:
-                        notices = validator_ref(&string_record, line_number);
-
-                        // For deserialization, we MUST trim fields to handle numeric types correctly.
-                        let mut trimmed_record = csv::StringRecord::with_capacity(
-                            string_record.as_slice().len(),
-                            string_record.len(),
-                        );
-                        for field in string_record.iter() {
-                            trimmed_record.push_field(field.trim());
-                        }
-
-                        // Deserialize from TRIMMED record
-                        let result = trimmed_record
-                            .deserialize(Some(headers_ref))
-                            .map_err(|err| {
-                                map_byte_record_error(file_ref, Some(headers_ref), line_number, err)
-                            });
-                        (index, line_number, result, notices)
-                    }
-                    Err(utf8_err) => {
-                        // Report UTF-8 error as ParseError if it prevents validation
-                        // Note: deserialize might still work if it doesn't touch bad bytes, but we prioritize data integrity
-                        let err = csv::Error::from(std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            utf8_err,
-                        ));
-                        return (
-                            index,
-                            line_number,
-                            Err(map_byte_record_error(
-                                file_ref,
-                                Some(headers_ref),
-                                line_number,
-                                err,
-                            )),
-                            notices,
-                        );
-                    }
-                }
-            })
-            .collect();
-
-    // Sort by index to restore original file order
-    results.sort_unstable_by_key(|(index, _, _, _)| *index);
-
-    // Split into rows, row_numbers, and errors
-    let mut rows = Vec::with_capacity(results.len());
-    let mut row_numbers = Vec::with_capacity(results.len());
+    let mut rows = Vec::with_capacity(processed.len());
+    let mut row_numbers = Vec::with_capacity(processed.len());
     let mut errors = scan_errors;
     let mut all_notices = Vec::new();
 
-    for (_, line_number, result, row_notices) in results {
+    for (line_number, result, row_notices) in processed {
         all_notices.extend(row_notices);
         match result {
             Ok(record) => {
@@ -340,6 +294,132 @@ where
         errors,
         all_notices,
     ))
+}
+
+/// Deserialize + validate a batch of byte records in parallel, preserving the
+/// original record order.
+///
+/// Work is split into row chunks; each rayon worker installs the thread-local
+/// interner hook (read by `StringId::deserialize`) and re-applies the captured
+/// validation context once per chunk. `chunks` on an indexed parallel iterator
+/// yields results in order, so the flattened output needs no post-sort.
+///
+/// Used both by the in-memory [`read_csv_from_reader_parallel`] and by the
+/// streaming loader, so the per-record semantics stay identical.
+#[cfg(feature = "parallel")]
+pub(crate) fn deserialize_validate_records<T, V>(
+    records: Vec<(u64, csv::ByteRecord)>,
+    headers: &csv::StringRecord,
+    file: &str,
+    validator: &V,
+    pool: &crate::StringPool,
+    ctx: &crate::validation_context::ValidationContextState,
+) -> Vec<(u64, Result<T, CsvParseError>, Vec<ValidationNotice>)>
+where
+    T: DeserializeOwned + Send,
+    V: Fn(&csv::StringRecord, u64) -> Vec<ValidationNotice> + Sync,
+{
+    use rayon::prelude::*;
+
+    // Rows handed to a single worker task. Large enough to amortize the
+    // per-chunk thread-local setup, small enough to keep every core busy.
+    const PARALLEL_CHUNK_ROWS: usize = 8192;
+
+    let nested: Vec<Vec<(u64, Result<T, CsvParseError>, Vec<ValidationNotice>)>> = records
+        .into_par_iter()
+        .chunks(PARALLEL_CHUNK_ROWS)
+        .map(|chunk| {
+            // Install thread-local hooks for this worker thread. Idempotent and
+            // cheap; re-applied per chunk. The interner points at the shared pool.
+            let chunk_pool = pool.clone();
+            let local_intern_cache = std::cell::RefCell::new(rustc_hash::FxHashMap::<
+                compact_str::CompactString,
+                gtfs_guru_model::StringId,
+            >::default());
+            let _interner_guard = gtfs_guru_model::set_thread_local_interner_scoped(move |s| {
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    return gtfs_guru_model::StringId(0);
+                }
+                let key = compact_str::CompactString::new(trimmed);
+                if let Some(id) = local_intern_cache.borrow().get(&key) {
+                    return *id;
+                }
+                let id = chunk_pool.intern(trimmed);
+                local_intern_cache.borrow_mut().insert(key, id);
+                id
+            });
+            let _ctx_guards = ctx.apply();
+
+            // Reused across rows in this chunk to avoid a per-row allocation.
+            let mut trimmed_record = csv::StringRecord::new();
+
+            let mut out = Vec::with_capacity(chunk.len());
+            for (line_number, record) in chunk {
+                out.push(deserialize_validate_one::<T, V>(
+                    record,
+                    line_number,
+                    headers,
+                    file,
+                    validator,
+                    &mut trimmed_record,
+                ));
+            }
+            out
+        })
+        .collect();
+
+    let mut flat = Vec::with_capacity(nested.iter().map(Vec::len).sum());
+    for chunk in nested {
+        flat.extend(chunk);
+    }
+    flat
+}
+
+/// Validate (untrimmed) and deserialize (trimmed) a single record.
+///
+/// The common case — valid UTF-8 — converts the byte record in place. Invalid
+/// bytes are replaced with U+FFFD per field so the row validator can flag them,
+/// matching the behavior of decoding the whole buffer up front.
+#[cfg(feature = "parallel")]
+fn deserialize_validate_one<T, V>(
+    record: csv::ByteRecord,
+    line_number: u64,
+    headers: &csv::StringRecord,
+    file: &str,
+    validator: &V,
+    trimmed_record: &mut csv::StringRecord,
+) -> (u64, Result<T, CsvParseError>, Vec<ValidationNotice>)
+where
+    T: DeserializeOwned,
+    V: Fn(&csv::StringRecord, u64) -> Vec<ValidationNotice>,
+{
+    let string_record = match csv::StringRecord::from_byte_record(record) {
+        Ok(string_record) => string_record,
+        Err(utf8_err) => {
+            let byte_record = utf8_err.into_byte_record();
+            let mut lossy = csv::StringRecord::new();
+            for field in byte_record.iter() {
+                lossy.push_field(&String::from_utf8_lossy(field));
+            }
+            lossy
+        }
+    };
+
+    // The untrimmed record is what the row validator inspects (whitespace,
+    // embedded newlines, invalid characters, ...).
+    let notices = validator(&string_record, line_number);
+
+    // Deserialization needs trimmed fields for numeric/enum types.
+    trimmed_record.clear();
+    for field in string_record.iter() {
+        trimmed_record.push_field(field.trim());
+    }
+    let result = trimmed_record
+        .deserialize(Some(headers))
+        .map_err(|err| map_byte_record_error(file, Some(headers), line_number, err));
+
+    (line_number, result, notices)
 }
 
 /// Map deserialization error from ByteRecord (used in parallel mode)
@@ -439,11 +519,12 @@ mod tests {
     #[cfg(feature = "parallel")]
     fn reads_headers_and_rows_parallel() {
         let data = "a,b\n1,2\n3,4\n5,6\n";
-        let (table, errors, notices) = read_csv_from_reader_parallel::<ExampleRow, _, _, _>(
+        let pool = crate::StringPool::new();
+        let (table, errors, notices) = read_csv_from_reader_parallel::<ExampleRow, _, _>(
             data.as_bytes(),
             "test.csv",
             |_, _| Vec::new(),
-            || {},
+            &pool,
         )
         .expect("parse csv");
 

--- a/crates/gtfs_validator_core/src/feed.rs
+++ b/crates/gtfs_validator_core/src/feed.rs
@@ -11,6 +11,13 @@ use std::collections::HashMap;
 #[cfg(feature = "parallel")]
 use std::sync::atomic::{AtomicU64, Ordering};
 
+/// Files at least this many bytes (uncompressed) use the streaming parallel
+/// reader, which overlaps unzip + boundary scan with the parallel parse. Below
+/// this size the producer-thread/channel overhead isn't worth it, so the
+/// in-memory parallel reader is used instead.
+#[cfg(feature = "parallel")]
+const STREAMING_THRESHOLD_BYTES: u64 = 32 * 1024 * 1024;
+
 use crate::geojson::{GeoJsonFeatureCollection, LocationsGeoJson};
 use crate::input::GtfsBytesReader;
 use crate::progress::ProgressHandler;
@@ -232,7 +239,7 @@ impl GtfsFeed {
                     p.on_start_file_load($file);
                 }
                 let mut local_notices = NoticeContainer::new();
-                let res = reader.read_optional_csv_with_notices($file, &mut local_notices);
+                let res = reader.read_optional_csv_with_notices($file, &mut local_notices, &pool);
                 record_table_status(&mut table_statuses, $file, &res, &local_notices);
                 notices.merge(local_notices);
                 if let Some(p) = progress {
@@ -422,9 +429,28 @@ impl GtfsFeed {
 
                 let start = std::time::Instant::now();
                 let mut local_notices = NoticeContainer::new();
-                let result = self
-                    .reader
-                    .read_optional_csv_with_notices(filename, &mut local_notices);
+                // Route very large files through the streaming reader (overlaps
+                // unzip + boundary scan with the parallel parse). The dominant
+                // file (stop_times) is the first arm of the top-level rayon::join,
+                // so it runs on the calling thread and never blocks a worker on
+                // the producer channel.
+                let is_large = self
+                    .file_sizes
+                    .get(filename)
+                    .is_some_and(|&size| size >= STREAMING_THRESHOLD_BYTES);
+                let result = if is_large {
+                    self.reader.read_optional_csv_streaming(
+                        filename,
+                        &mut local_notices,
+                        &self.pool,
+                    )
+                } else {
+                    self.reader.read_optional_csv_with_notices(
+                        filename,
+                        &mut local_notices,
+                        &self.pool,
+                    )
+                };
 
                 // Output per-file timing if GTFS_PERF_DEBUG is set
                 if std::env::var("GTFS_PERF_DEBUG").is_ok() {
@@ -1031,7 +1057,7 @@ impl GtfsFeed {
                     p.on_start_file_load($file);
                 }
                 let mut local_notices = NoticeContainer::new();
-                let res = reader.read_optional_csv_with_notices($file, &mut local_notices);
+                let res = reader.read_optional_csv_with_notices($file, &mut local_notices, &pool);
                 record_table_status(&mut table_statuses, $file, &res, &local_notices);
                 notices.merge(local_notices);
                 if let Some(p) = progress {

--- a/crates/gtfs_validator_core/src/input.rs
+++ b/crates/gtfs_validator_core/src/input.rs
@@ -252,6 +252,7 @@ impl GtfsInputReader {
         &self,
         file_name: &str,
         notices: &mut NoticeContainer,
+        pool: &crate::StringPool,
     ) -> Result<CsvTable<T>, GtfsInputError> {
         let data = self.read_file(file_name)?;
         if strip_utf8_bom(&data).is_empty() {
@@ -271,7 +272,7 @@ impl GtfsInputReader {
             Ok(h) => h.clone(),
             Err(_) => {
                 let (table, _, _) =
-                    read_csv_from_reader_parallel(data_bytes, file_name, |_, _| Vec::new(), || {})
+                    read_csv_from_reader_parallel(data_bytes, file_name, |_, _| Vec::new(), pool)
                         .map_err(GtfsInputError::Csv)?;
                 return Ok(table);
             }
@@ -285,7 +286,7 @@ impl GtfsInputReader {
             data_bytes,
             file_name,
             |record, line| validator.validate_row(record, line),
-            || {},
+            pool,
         )
         .map_err(GtfsInputError::Csv)?;
 
@@ -307,6 +308,7 @@ impl GtfsInputReader {
         &self,
         file_name: &str,
         notices: &mut NoticeContainer,
+        _pool: &crate::StringPool,
     ) -> Result<CsvTable<T>, GtfsInputError> {
         let data = self.read_file(file_name)?;
         let data_str = decode_utf8_lossy(&data);
@@ -344,6 +346,7 @@ impl GtfsInputReader {
         &self,
         file_name: &str,
         notices: &mut NoticeContainer,
+        pool: &crate::StringPool,
     ) -> Result<Option<CsvTable<T>>, GtfsInputError> {
         match self.read_file(file_name) {
             Ok(data) => {
@@ -367,7 +370,7 @@ impl GtfsInputReader {
                             data_bytes,
                             file_name,
                             |_, _| Vec::new(),
-                            || {},
+                            pool,
                         )
                         .map_err(GtfsInputError::Csv)?;
                         return Ok(Some(table));
@@ -393,7 +396,7 @@ impl GtfsInputReader {
                             validator.validate_row(record, line)
                         }
                     },
-                    || {},
+                    pool,
                 )
                 .map_err(GtfsInputError::Csv)?;
 
@@ -421,6 +424,7 @@ impl GtfsInputReader {
         &self,
         file_name: &str,
         notices: &mut NoticeContainer,
+        _pool: &crate::StringPool,
     ) -> Result<Option<CsvTable<T>>, GtfsInputError> {
         match self.read_file(file_name) {
             Ok(data) => {
@@ -465,6 +469,230 @@ impl GtfsInputReader {
             Err(GtfsInputError::MissingFile(_)) => Ok(None),
             Err(err) => Err(err),
         }
+    }
+
+    /// Streaming parallel CSV reader for very large zip members (e.g.
+    /// `stop_times.txt` on big feeds).
+    ///
+    /// A producer thread decompresses the zip entry and scans CSV record
+    /// boundaries, handing batches of byte records to the rayon pool for
+    /// deserialization + validation while it keeps decompressing. This overlaps
+    /// the otherwise-serial unzip + boundary scan with the parallel parse and
+    /// bounds peak memory (only a few batches are in flight at once).
+    ///
+    /// Falls back to the in-memory parallel reader for non-zip sources. The
+    /// caller (the feed loader) only routes large files here, and the dominant
+    /// one runs on the main thread, so no rayon worker ever blocks on the
+    /// producer channel.
+    #[cfg(feature = "parallel")]
+    pub(crate) fn read_optional_csv_streaming<T: DeserializeOwned + Send>(
+        &self,
+        file_name: &str,
+        notices: &mut NoticeContainer,
+        pool: &crate::StringPool,
+    ) -> Result<Option<CsvTable<T>>, GtfsInputError> {
+        use crate::csv_reader::{
+            deserialize_validate_records, map_csv_error, map_io_error, skip_utf8_bom,
+        };
+        use std::sync::mpsc::sync_channel;
+
+        if self.source != GtfsInputSource::Zip {
+            return self.read_optional_csv_with_notices(file_name, notices, pool);
+        }
+
+        // Rows per batch handed to the consumer, and how many batches may be
+        // buffered ahead of it (this bounds peak memory).
+        const BATCH_ROWS: usize = 65_536;
+        const CHANNEL_CAPACITY: usize = 3;
+
+        enum Msg {
+            Headers(csv::ByteRecord),
+            Batch(Vec<(u64, csv::ByteRecord)>),
+            ScanError(CsvParseError),
+        }
+
+        let (tx, rx) = sync_channel::<Msg>(CHANNEL_CAPACITY);
+        let path = &self.path;
+
+        std::thread::scope(|scope| -> Result<Option<CsvTable<T>>, GtfsInputError> {
+            // ---- Producer: stream-decompress + scan record boundaries. ----
+            let producer = scope.spawn(move || -> Result<bool, GtfsInputError> {
+                let file = File::open(path).map_err(|err| GtfsInputError::Io {
+                    path: path.clone(),
+                    source: err,
+                })?;
+                let mut archive =
+                    ZipArchive::new(file).map_err(|err| GtfsInputError::ZipArchive {
+                        path: path.clone(),
+                        source: err,
+                    })?;
+                let Some(index) = locate_zip_member(&mut archive, file_name)? else {
+                    return Ok(false); // missing file
+                };
+                let zipped = archive
+                    .by_index(index)
+                    .map_err(|err| GtfsInputError::ZipFile {
+                        file: file_name.to_string(),
+                        source: err,
+                    })?;
+
+                let mut buf_reader = std::io::BufReader::with_capacity(1 << 20, zipped);
+                skip_utf8_bom(&mut buf_reader)
+                    .map_err(|err| GtfsInputError::Csv(map_io_error(file_name, err)))?;
+
+                let mut csv_reader = csv::ReaderBuilder::new()
+                    .has_headers(true)
+                    .flexible(true)
+                    .trim(csv::Trim::None)
+                    .from_reader(buf_reader);
+
+                let headers = csv_reader
+                    .byte_headers()
+                    .map_err(|err| GtfsInputError::Csv(map_csv_error(file_name, None, err)))?
+                    .clone();
+                let mut headers_for_errors = csv::StringRecord::new();
+                for field in headers.iter() {
+                    headers_for_errors.push_field(&String::from_utf8_lossy(field));
+                }
+                if tx.send(Msg::Headers(headers)).is_err() {
+                    return Ok(true); // consumer dropped
+                }
+
+                let mut batch: Vec<(u64, csv::ByteRecord)> = Vec::with_capacity(BATCH_ROWS);
+                let mut record_index = 0usize;
+                let mut records = csv_reader.into_byte_records();
+                while let Some(result) = records.next() {
+                    match result {
+                        Ok(record) => {
+                            let line_number = record
+                                .position()
+                                .map(|p| p.line())
+                                .unwrap_or((record_index + 2) as u64);
+                            batch.push((line_number, record));
+                            record_index += 1;
+                            if batch.len() >= BATCH_ROWS {
+                                let full =
+                                    std::mem::replace(&mut batch, Vec::with_capacity(BATCH_ROWS));
+                                if tx.send(Msg::Batch(full)).is_err() {
+                                    return Ok(true);
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            let parse_err =
+                                map_csv_error(file_name, Some(&headers_for_errors), err);
+                            if tx.send(Msg::ScanError(parse_err)).is_err() {
+                                return Ok(true);
+                            }
+                        }
+                    }
+                }
+                if !batch.is_empty() {
+                    let _ = tx.send(Msg::Batch(batch));
+                }
+                Ok(true)
+            });
+
+            // ---- Consumer: build validator from headers, deserialize batches. ----
+            let ctx = crate::validation_context::ValidationContextState::capture();
+            let mut headers_vec: Option<Vec<String>> = None;
+            let mut headers_trimmed: Option<csv::StringRecord> = None;
+            let mut validator: Option<RowValidator> = None;
+            let mut has_header_errors = false;
+
+            let mut rows: Vec<T> = Vec::new();
+            let mut row_numbers: Vec<u64> = Vec::new();
+            let mut parse_errors: Vec<CsvParseError> = Vec::new();
+            let mut collected_notices: Vec<ValidationNotice> = Vec::new();
+
+            for msg in rx {
+                match msg {
+                    Msg::Headers(byte_headers) => {
+                        // Untrimmed header names feed header validation and the row
+                        // validator (matching the in-memory path); a trimmed copy
+                        // is used as the deserialization header map.
+                        let untrimmed: Vec<String> = byte_headers
+                            .iter()
+                            .map(|field| String::from_utf8_lossy(field).into_owned())
+                            .collect();
+                        let mut header_notices = NoticeContainer::new();
+                        validate_headers(file_name, &untrimmed, &mut header_notices);
+                        has_header_errors = header_notices
+                            .iter()
+                            .any(|notice| notice.severity == NoticeSeverity::Error);
+                        notices.merge(header_notices);
+                        validator = Some(RowValidator::new(file_name, untrimmed.clone()));
+
+                        let mut trimmed = csv::StringRecord::new();
+                        for field in untrimmed.iter() {
+                            trimmed.push_field(field.trim());
+                        }
+                        headers_vec = Some(
+                            untrimmed
+                                .iter()
+                                .map(|field| field.trim().to_string())
+                                .collect(),
+                        );
+                        headers_trimmed = Some(trimmed);
+                    }
+                    Msg::Batch(batch) => {
+                        let (Some(validator), Some(headers_trimmed)) =
+                            (validator.as_ref(), headers_trimmed.as_ref())
+                        else {
+                            continue;
+                        };
+                        let processed = deserialize_validate_records::<T, _>(
+                            batch,
+                            headers_trimmed,
+                            file_name,
+                            &|record: &csv::StringRecord, line: u64| {
+                                if has_header_errors {
+                                    Vec::new()
+                                } else {
+                                    validator.validate_row(record, line)
+                                }
+                            },
+                            pool,
+                            &ctx,
+                        );
+                        for (line_number, result, row_notices) in processed {
+                            if !has_header_errors {
+                                collected_notices.extend(row_notices);
+                            }
+                            match result {
+                                Ok(record) => {
+                                    rows.push(record);
+                                    row_numbers.push(line_number);
+                                }
+                                Err(err) => parse_errors.push(err),
+                            }
+                        }
+                    }
+                    Msg::ScanError(err) => parse_errors.push(err),
+                }
+            }
+
+            let found = producer.join().expect("csv streaming producer panicked")?;
+            if !found {
+                return Ok(None);
+            }
+
+            let table = CsvTable {
+                headers: headers_vec.unwrap_or_default(),
+                rows,
+                row_numbers,
+            };
+            for notice in collected_notices {
+                notices.push(notice);
+            }
+            for error in parse_errors {
+                if skip_csv_parse_error(&table, &error) {
+                    continue;
+                }
+                notices.push_csv_error(&error);
+            }
+            Ok(Some(table))
+        })
     }
 
     fn read_from_directory(&self, file_name: &str) -> Result<Vec<u8>, GtfsInputError> {
@@ -653,6 +881,49 @@ fn strip_utf8_bom(data: &[u8]) -> &[u8] {
     } else {
         data
     }
+}
+
+/// Locate the best-matching root-level zip member for `file_name`, returning its
+/// index. Mirrors the matching used by [`GtfsInputReader::read_from_zip`]: an
+/// exact name match wins, otherwise a case-insensitive match (preferring the
+/// lexicographically smallest name). Nested members are ignored.
+#[cfg(feature = "parallel")]
+fn locate_zip_member(
+    archive: &mut ZipArchive<File>,
+    file_name: &str,
+) -> Result<Option<usize>, GtfsInputError> {
+    let target = file_name.to_ascii_lowercase();
+    let mut ci_index: Option<usize> = None;
+    let mut ci_name: Option<String> = None;
+    for index in 0..archive.len() {
+        let (name, is_dir) = {
+            let file = archive
+                .by_index(index)
+                .map_err(|err| GtfsInputError::ZipFile {
+                    file: file_name.to_string(),
+                    source: err,
+                })?;
+            (file.name().to_string(), file.is_dir())
+        };
+        if is_dir {
+            continue;
+        }
+        if name.contains('/') || name.contains('\\') {
+            continue; // root-level members only
+        }
+        if name == file_name {
+            return Ok(Some(index)); // exact match wins
+        }
+        let lower = name.to_ascii_lowercase();
+        if lower == target {
+            let replace = ci_name.as_ref().map(|best| lower < *best).unwrap_or(true);
+            if replace {
+                ci_index = Some(index);
+                ci_name = Some(lower);
+            }
+        }
+    }
+    Ok(ci_index)
 }
 
 fn list_files_in_directory(path: &Path) -> Result<Vec<String>, GtfsInputError> {
@@ -955,6 +1226,7 @@ impl GtfsBytesReader {
         &self,
         file_name: &str,
         notices: &mut NoticeContainer,
+        pool: &crate::StringPool,
     ) -> Result<CsvTable<T>, GtfsInputError> {
         let data = self.read_file(file_name)?;
         let data_str = decode_utf8_lossy(&data);
@@ -970,7 +1242,7 @@ impl GtfsBytesReader {
             Ok(h) => h.clone(),
             Err(_) => {
                 let (table, _, _) =
-                    read_csv_from_reader_parallel(data_bytes, file_name, |_, _| Vec::new(), || {})
+                    read_csv_from_reader_parallel(data_bytes, file_name, |_, _| Vec::new(), pool)
                         .map_err(GtfsInputError::Csv)?;
                 return Ok(table);
             }
@@ -984,7 +1256,7 @@ impl GtfsBytesReader {
             data_bytes,
             file_name,
             |record, line| validator.validate_row(record, line),
-            || {},
+            pool,
         )
         .map_err(GtfsInputError::Csv)?;
 
@@ -1006,6 +1278,7 @@ impl GtfsBytesReader {
         &self,
         file_name: &str,
         notices: &mut NoticeContainer,
+        _pool: &crate::StringPool,
     ) -> Result<CsvTable<T>, GtfsInputError> {
         let data = self.read_file(file_name)?;
         let data_str = decode_utf8_lossy(&data);
@@ -1043,6 +1316,7 @@ impl GtfsBytesReader {
         &self,
         file_name: &str,
         notices: &mut NoticeContainer,
+        pool: &crate::StringPool,
     ) -> Result<Option<CsvTable<T>>, GtfsInputError> {
         match self.read_file(file_name) {
             Ok(data) => {
@@ -1062,7 +1336,7 @@ impl GtfsBytesReader {
                             data_bytes,
                             file_name,
                             |_, _| Vec::new(),
-                            || {},
+                            pool,
                         )
                         .map_err(GtfsInputError::Csv)?;
                         return Ok(Some(table));
@@ -1077,7 +1351,7 @@ impl GtfsBytesReader {
                     data_bytes,
                     file_name,
                     |record, line| validator.validate_row(record, line),
-                    || {},
+                    pool,
                 )
                 .map_err(GtfsInputError::Csv)?;
 
@@ -1103,6 +1377,7 @@ impl GtfsBytesReader {
         &self,
         file_name: &str,
         notices: &mut NoticeContainer,
+        _pool: &crate::StringPool,
     ) -> Result<Option<CsvTable<T>>, GtfsInputError> {
         match self.read_file(file_name) {
             Ok(data) => {
@@ -1297,6 +1572,49 @@ mod tests {
         fs::remove_dir_all(&dir).ok();
     }
 
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn streaming_csv_member_read_error_is_not_silently_loaded() {
+        let dir = temp_path("gtfs_streaming_bad_member");
+        fs::create_dir_all(&dir).expect("create dir");
+        let zip_path = dir.join("feed.zip");
+
+        let zip_file = File::create(&zip_path).expect("create zip");
+        let mut zip = ZipWriter::new(zip_file);
+        let options = FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        zip.start_file("stops.txt", options).expect("zip file");
+        zip.write_all(b"a,b\n1,2\n").expect("zip data");
+        zip.finish().expect("finish zip");
+
+        let mut zip_bytes = fs::read(&zip_path).expect("read zip");
+        assert_eq!(&zip_bytes[0..4], b"PK\x03\x04");
+        let name_len = u16::from_le_bytes([zip_bytes[26], zip_bytes[27]]) as usize;
+        let extra_len = u16::from_le_bytes([zip_bytes[28], zip_bytes[29]]) as usize;
+        let data_start = 30 + name_len + extra_len;
+        zip_bytes[data_start] ^= 0xff;
+        fs::write(&zip_path, zip_bytes).expect("corrupt zip member data");
+
+        let input = GtfsInput::from_path(&zip_path).expect("input");
+        let reader = input.reader();
+        let mut notices = NoticeContainer::new();
+        let pool = crate::StringPool::new();
+
+        let err = reader
+            .read_optional_csv_streaming::<ExampleRow>("stops.txt", &mut notices, &pool)
+            .expect_err("member read error must be a CSV error");
+
+        match err {
+            GtfsInputError::Csv(err) => {
+                assert_eq!(err.file, "stops.txt");
+                assert!(!err.message.is_empty());
+            }
+            other => panic!("expected CSV error, got {other:?}"),
+        }
+        assert!(notices.is_empty());
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
     #[test]
     fn reads_file_from_directory_case_insensitive() {
         let dir = temp_path("gtfs_dir_case");
@@ -1357,8 +1675,9 @@ mod tests {
         let input = GtfsInput::from_path(&dir).expect("input");
         let reader = input.reader();
         let mut notices = NoticeContainer::new();
+        let pool = crate::StringPool::new();
         let table = reader
-            .read_csv_with_notices::<gtfs_guru_model::Route>("routes.txt", &mut notices)
+            .read_csv_with_notices::<gtfs_guru_model::Route>("routes.txt", &mut notices, &pool)
             .expect("read csv");
 
         assert!(table.rows.is_empty());


### PR DESCRIPTION
## What

Parallelizes the GTFS CSV loader, which was the dominant cost on large feeds — loading (not validation) was ~90% of wall time, and the "parallel" reader was actually sequential.

- `read_csv_from_reader_parallel` now genuinely parallelizes deserialize + per-row validation across rayon. It previously collected byte records and then deserialized them with `.into_iter()` (sequential), because `StringId::deserialize` reads a thread-local interner hook. Each worker now installs that hook (via a new `set_thread_local_interner_scoped` guard) + the captured `ValidationContextState` per chunk; results are collected in original order (no post-sort).
- New streaming path for large tables (≥ 32 MB): a producer thread stream-decompresses the zip entry and scans CSV record boundaries, handing batches to the rayon pool — overlapping unzip with parsing and bounding peak memory (only a few batches in flight). Gated so only the one giant table streams, and it runs on the main thread (first arm of the top-level `rayon::join`), so no rayon worker ever blocks on the producer channel.
- `StringPool` (already a concurrent `DashMap`) is threaded through the readers so all workers share one interner.

## Why / numbers

Closes #5 (benchmark vs gtfsvtor). MBTA feed (252 MB `stop_times.txt`, 5.4M rows), Apple M3 Pro, warm cache, median of 7:

| | before | after |
|---|---|---|
| feed loading | ~7.9 s | ~1.9 s |
| full run | ~8.5 s | ~2.4 s |

Head-to-head, same machine: gtfs.guru **2.36 s** vs gtfsvtor 1.0.3 **6.51 s** (~2.8×); on a tiny feed ~34× (JVM startup dominates theirs).

## Correctness

- Streaming output is byte-identical (`totalNotices`) to the in-memory path and invariant to thread count (verified on MBTA: multi-thread == single-thread).
- WASM unaffected — `parallel` stays disabled there (no browser threads), so it keeps using the sequential reader.
- All workspace tests pass (302 in core), `cargo fmt --check` clean.
