### PR TITLE
feat(report): show feed_version in Feed Info (JSON + HTML)

### DIFF
--- a/crates/gtfs_validator_report/src/html.rs
+++ b/crates/gtfs_validator_report/src/html.rs
@@ -735,6 +735,9 @@ fn build_feed_info_entries(info: &ReportFeedInfo) -> Vec<(String, String)> {
     if let Some(value) = info.feed_end_date.as_ref() {
         entries.push(("Feed End Date".to_string(), value.clone()));
     }
+    if let Some(value) = info.feed_version.as_ref() {
+        entries.push(("Feed Version".to_string(), value.clone()));
+    }
     if info.feed_service_window_start.is_some() || info.feed_service_window_end.is_some() {
         entries.push(("Service Window".to_string(), service_window_display(info)));
     }

--- a/crates/gtfs_validator_report/src/lib.rs
+++ b/crates/gtfs_validator_report/src/lib.rs
@@ -285,6 +285,9 @@ pub struct ReportFeedInfo {
     pub feed_service_window_start: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub feed_service_window_end: Option<String>,
+    // gtfs.guru extension: not part of the canonical validator's report schema.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub feed_version: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -547,6 +550,9 @@ fn build_feed_info(feed: &GtfsFeed) -> ReportFeedInfo {
     let has_end_date = info_table
         .map(|table| has_header(table, "feed_end_date"))
         .unwrap_or(false);
+    let has_feed_version = info_table
+        .map(|table| has_header(table, "feed_version"))
+        .unwrap_or(false);
     let has_service_window = feed.calendar.is_some() || feed.calendar_dates.is_some();
     let (service_start, service_end) = compute_service_window(feed);
     let (service_start_str, service_end_str) = format_service_window(service_start, service_end);
@@ -589,6 +595,11 @@ fn build_feed_info(feed: &GtfsFeed) -> ReportFeedInfo {
         }),
         feed_service_window_start: has_service_window.then(|| service_start_str),
         feed_service_window_end: has_service_window.then(|| service_end_str),
+        feed_version: has_feed_version.then(|| {
+            info_row
+                .and_then(|row| row.feed_version.as_ref().map(|s| s.to_string()))
+                .unwrap_or_default()
+        }),
     }
 }
 

--- a/scripts/compare_reports.py
+++ b/scripts/compare_reports.py
@@ -38,6 +38,7 @@ def normalize_report(
     data,
     ignore_summary: bool,
     ignore_summary_fields,
+    ignore_feed_info_fields,
     ignore_notice_order: bool,
     sort_summary_arrays: bool,
 ):
@@ -54,6 +55,15 @@ def normalize_report(
                 summary.pop(field, None)
             data = dict(data)
             data["summary"] = summary
+        if ignore_feed_info_fields and isinstance(data.get("summary"), dict):
+            summary = dict(data["summary"])
+            if isinstance(summary.get("feedInfo"), dict):
+                feed_info = dict(summary["feedInfo"])
+                for field in ignore_feed_info_fields:
+                    feed_info.pop(field, None)
+                summary["feedInfo"] = feed_info
+                data = dict(data)
+                data["summary"] = summary
         if sort_summary_arrays and isinstance(data.get("summary"), dict):
             summary = dict(data["summary"])
             for key in ("files", "gtfsFeatures"):
@@ -87,6 +97,7 @@ def compare_json(
     right_path: Path,
     ignore_summary: bool,
     ignore_summary_fields,
+    ignore_feed_info_fields,
     ignore_notice_order: bool,
     sort_summary_arrays: bool,
 ) -> bool:
@@ -102,6 +113,7 @@ def compare_json(
         load_json(left_path),
         ignore_summary=ignore_summary,
         ignore_summary_fields=ignore_summary_fields,
+        ignore_feed_info_fields=ignore_feed_info_fields,
         ignore_notice_order=ignore_notice_order,
         sort_summary_arrays=sort_summary_arrays,
     )
@@ -109,6 +121,7 @@ def compare_json(
         load_json(right_path),
         ignore_summary=ignore_summary,
         ignore_summary_fields=ignore_summary_fields,
+        ignore_feed_info_fields=ignore_feed_info_fields,
         ignore_notice_order=ignore_notice_order,
         sort_summary_arrays=sort_summary_arrays,
     )
@@ -155,7 +168,10 @@ def main() -> int:
     parser.add_argument(
         "--strip-runtime-fields",
         action="store_true",
-        help="Ignore validatedAt, validationTimeSeconds, memoryUsageRecords, outputDirectory.",
+        help=(
+            "Ignore validatedAt, validationTimeSeconds, memoryUsageRecords, "
+            "outputDirectory, and gtfs.guru report extensions (feedInfo.feedVersion)."
+        ),
     )
     parser.add_argument(
         "--ignore-input",
@@ -191,6 +207,7 @@ def main() -> int:
     checks.extend((name, name) for name in args.extra_json)
 
     ignore_summary_fields = list(args.ignore_summary_field)
+    ignore_feed_info_fields = []
     if args.strip_runtime_fields:
         ignore_summary_fields.extend(
             [
@@ -200,6 +217,8 @@ def main() -> int:
                 "outputDirectory",
             ]
         )
+        # gtfs.guru extends the canonical schema; drop extensions for parity checks.
+        ignore_feed_info_fields.append("feedVersion")
     if args.ignore_input:
         ignore_summary_fields.append("gtfsInput")
     if args.ignore_validator_version:
@@ -215,6 +234,7 @@ def main() -> int:
             right_path,
             ignore_summary=args.ignore_summary,
             ignore_summary_fields=ignore_summary_fields,
+            ignore_feed_info_fields=ignore_feed_info_fields,
             ignore_notice_order=args.ignore_notice_order,
             sort_summary_arrays=args.sort_summary_arrays,
         ):


### PR DESCRIPTION
## Summary
Fixes #10 — the Feed Info block now includes the feed version.

- `report.json`: new `summary.feedInfo.feedVersion` (emitted only when `feed_info.txt` declares the `feed_version` column)
- HTML report: new **Feed Version** row in the Feed Info card
- The canonical validator does not report this field, so it is a gtfs.guru extension; `scripts/compare_reports.py --strip-runtime-fields` now drops it before golden parity comparison

## Testing
- `cargo test -p gtfs-guru-report`, `cargo fmt --check`, clippy clean
- Validated the Kapnos feed end-to-end: `feedVersion: powerbi-20260705` appears in JSON and HTML
- Verified `compare_reports.py` treats a canonical report (without the field) as matching under `--strip-runtime-fields`

🤖 Generated with [Claude Code](https://claude.com/claude-code)