### PR TITLE
Added OS-distribution-specific dependencies installation to the steps…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ __pycache__/
 # wasm-pack multithreaded out-dir (pkg/ self-ignores via its own .gitignore;
 # build-wasm.sh strips that from pkg-mt so the website copies stay tracked)
 crates/gtfs_validator_wasm/pkg-mt/
+crates/gtfs_validator_gui/gen/schemas/linux-schema.json

--- a/README.md
+++ b/README.md
@@ -282,7 +282,17 @@ We welcome contributions! Whether it's adding new rules, fixing bugs, or improvi
 
 1. Clone the repo: `git clone https://github.com/abasis-ltd/gtfs.guru`
 2. Install Rust: [rustup.rs](https://rustup.rs)
-3. Run tests: `cargo test --workspace`
+3. Install the dependencies:\
+RHEL _(and therefore Fedora Linux)_:
+```terminal
+sudo dnf install pkgconf-pkg-config glib2-devel gtk3-devel javascriptcoregtk4.1-devel libsoup3-devel webkit2gtk4.1-devel
+```
+Debian _(and therefore Ubuntu)_:
+```terminal
+sudo apt-get update
+sudo apt install pkg-config libglib2.0-dev libgtk-3-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
+```
+4. Run tests: `cargo test --workspace`
 
 ## 📄 License
 


### PR DESCRIPTION
… for running workspace tests

# Description
Previously, following the steps for running worspace tests would result in an error by cargo complaining about several libraries missing. Cargo couldn't install them automatically because each OS has its own way to do that. I included the instructions for Debian and RHEL.

I tested the results using a virtual machine with Debian and my host machine with Fedora Linux (the upstreaam of RHEL

- [✅] I have performed a self-review of my own code
