### PR TITLE
Solution for GTF-1: the gtfs-guru-gui cargo package needs OS-specific libraries that need to be installed manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ __pycache__/
 # wasm-pack multithreaded out-dir (pkg/ self-ignores via its own .gitignore;
 # build-wasm.sh strips that from pkg-mt so the website copies stay tracked)
 crates/gtfs_validator_wasm/pkg-mt/
+crates/gtfs_validator_gui/gen/schemas/linux-schema.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@
 - Workspace crates live in `crates/`; core logic is in `gtfs_validator_core` with CLI, web, WASM, Python, and GUI front-ends.
 - Benchmark inputs and the Java baseline live in `benchmark-feeds/` (`gtfs-validator.jar`).
 
+## System Dependencies (Linux)
+
+The GUI crate (Tauri) is part of the default workspace, so a plain `cargo build`/`cargo test` on Linux needs system packages installed first, or the build fails with missing `pkg-config` headers. See `docs/system-dependencies.md` for the exact package list.
+
 ## Essential Commands
 
 - `cargo build` (workspace build)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## System Dependencies (Linux)
 
-The GUI crate (Tauri) is part of the default workspace, so a plain `cargo build`/`cargo test` on Linux needs system packages installed first, or the build fails with missing `pkg-config` headers. See `docs/system-dependencies.md` for the exact package list.
+See `docs/system-dependencies.md` for the package list.
 
 ## Essential Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,8 @@ Unsure where to begin contributing to GTFS Guru? You can start by looking throug
 
 You will need [Rust](https://www.rust-lang.org/tools/install) installed. We recommend using `rustup` to manage your Rust installation.
 
+The workspace includes the desktop GUI crate (Tauri), so a plain `cargo build`/`cargo test` on Linux also needs its system libraries installed first – see [`docs/system-dependencies.md`](docs/system-dependencies.md) for the exact package list.
+
 ### Building parts of the project
 
 The project is a workspace with multiple crates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Unsure where to begin contributing to GTFS Guru? You can start by looking throug
 
 You will need [Rust](https://www.rust-lang.org/tools/install) installed. We recommend using `rustup` to manage your Rust installation.
 
-The workspace includes the desktop GUI crate (Tauri), so a plain `cargo build`/`cargo test` on Linux also needs its system libraries installed first – see [`docs/system-dependencies.md`](docs/system-dependencies.md) for the exact package list.
+See [`docs/system-dependencies.md`](docs/system-dependencies.md) for the package list.
 
 ### Building parts of the project
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ We welcome contributions! Whether it's adding new rules, fixing bugs, or improvi
 
 1. Clone the repo: `git clone https://github.com/abasis-ltd/gtfs.guru`
 2. Install Rust: [rustup.rs](https://rustup.rs)
-3. Run tests: `cargo test --workspace`
+3. On Linux, install the system dependencies: see [`docs/system-dependencies.md`](docs/system-dependencies.md)
+4. Run tests: `cargo test --workspace`
 
 ## 📄 License
 

--- a/docs/agents/gui.md
+++ b/docs/agents/gui.md
@@ -8,7 +8,8 @@
 ## Prerequisites
 
 - Rust (stable)
-- Tauri CLI (see https://tauri.app/v1/guides/getting-started/prerequisites)
+- Tauri CLI (`cargo install tauri-cli`)
+- On Linux, GTK/WebKit system packages – see `docs/system-dependencies.md`
 - Node.js only if frontend tooling is needed
 
 ## Development and Build

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,8 @@
 
 ## From Source (Rust)
 
+On Linux, install the system dependencies first – see [System Dependencies](system-dependencies.md).
+
 ```bash
 git clone https://github.com/abasis-ltd/gtfs.guru
 cd gtfs.guru

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -2,7 +2,7 @@
 
 The desktop GUI crate (Tauri) is part of the default cargo workspace, so a
 plain `cargo build` or `cargo test` on Linux needs these system libraries
-installed first — without them the build fails with missing `pkg-config`
+installed first – without them the build fails with missing `pkg-config`
 headers for GTK/WebKit.
 
 macOS and Windows need no extra system packages beyond Rust itself.
@@ -19,7 +19,3 @@ sudo dnf install pkgconf-pkg-config glib2-devel gtk3-devel javascriptcoregtk4.1-
 sudo apt-get update
 sudo apt install pkg-config libglib2.0-dev libgtk-3-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
 ```
-
-This list tracks whatever `tauri-build` currently requires on Linux; if a
-future Tauri upgrade changes it, update it only here — every other doc links
-to this page instead of repeating the package list.

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -1,0 +1,25 @@
+# System Dependencies (Linux)
+
+The desktop GUI crate (Tauri) is part of the default cargo workspace, so a
+plain `cargo build` or `cargo test` on Linux needs these system libraries
+installed first — without them the build fails with missing `pkg-config`
+headers for GTK/WebKit.
+
+macOS and Windows need no extra system packages beyond Rust itself.
+
+### Fedora / RHEL
+
+```bash
+sudo dnf install pkgconf-pkg-config glib2-devel gtk3-devel javascriptcoregtk4.1-devel libsoup3-devel webkit2gtk4.1-devel
+```
+
+### Debian / Ubuntu
+
+```bash
+sudo apt-get update
+sudo apt install pkg-config libglib2.0-dev libgtk-3-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
+```
+
+This list tracks whatever `tauri-build` currently requires on Linux; if a
+future Tauri upgrade changes it, update it only here — every other doc links
+to this page instead of repeating the package list.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Installation: installation.md
+  - System Dependencies: system-dependencies.md
   - Usage: usage.md
   - LLM Guide: llm.md
   - Python API: python_api.md


### PR DESCRIPTION
[Issue GTF-1 on Linear](https://linear.app/abasis/issue/GTF-1/the-gtfs-guru-gui-cargo-package-needs-os-specific-libraries-that-need)

Changelog:
 - The `docs/system-dependencies.md` file has been added to contain the exact commands for installing the dependencies on widely used Linux distributions – Debian Linux and RHEL;
 - The `AGENTS.md`, `CONTRIBUTING.md`, `docs/agents/gui.md`, `docs/installation.md`, `README.md` files now refer to `docs/system-dependencies.md`;
 - The `mkdocs.yml` file's navigation layout now refers to `docs/system-dependencies.md`;
 - The `crates/gtfs_validator_gui/gen/schemas/linux-schema.json` file has been added to .gitignore (off topic);
 - The TAURI CLI installation method is now included directly in `docs/agents/gui.md` instead of referring to a webpage under `tauri.app` (off topic).