### PR TITLE
Solution for GTF-3: running the gui program on Linux with Wayland crashes the window without a documented fix

### DIFF
--- a/docs/agents/gui.md
+++ b/docs/agents/gui.md
@@ -22,3 +22,21 @@ cargo tauri build
 ```
 
 Release artifacts are written under `target/release/bundle/`.
+
+## Running inside a Wayland session
+
+On a Linux host with Wayland, WebKitGTK's hardware-accelerated
+compositing may fail on startup, and the app exits immediately with:
+
+```text
+Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display.
+```
+
+Work around it by disabling the DMA-BUF renderer, which falls back to
+software compositing:
+
+```bash
+WEBKIT_DISABLE_DMABUF_RENDERER=1 ./target/debug/gtfs-guru-desktop
+```
+
+This also applies to `cargo tauri dev` (set the variable before the command).


### PR DESCRIPTION
[Issue GTF-3 on Linear](https://linear.app/abasis/issue/GTF-3/running-the-gui-program-on-linux-with-wayland-crashes-the-window)

The changelog:
 - The `docs/agents/gui.md` file now documents the fix for running the gui program inside a Wayland session