### PR TITLE
Solution for GTF-13: AGENTS.md mentions a package named "gtfs_validator_core" instead of "gtfs-guru-core"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ See `docs/system-dependencies.md` for the package list.
 - `cargo build` (workspace build)
 - `cargo build --release -p gtfs-guru` (CLI binary)
 - `cargo run --release -p gtfs-guru-web` (local API server)
-- `cargo test` or `cargo test -p gtfs_validator_core`
+- `cargo test` or `cargo test -p gtfs-guru-core`
 - `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings`
 - Golden suite: build the release CLI first and hand it to the runner, so it
   does not fall back to `cargo run` and build the 13-16 GB debug tree:


### PR DESCRIPTION
[The issue GTF-13 on Linear](https://linear.app/abasis/issue/GTF-13/agentsmd-mentions-a-package-named-gtfs-validator-core-instead-of-gtfs)
The changelog:
 - The `AGENTS.md` file now uses the proper package name, `gtfs-guru-core`, instead of `gtfs_validator_core`