### PR TITLE
Implementation of GTF-15: use proper mention of the Java validator in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,7 @@
 
 ## Overview
 
-- Rust implementation of the Java validator at `../gtfs-validator-java`
-  (`/Users/akimov/Documents/GitHub/gtfs-validator-java`).
+- A Rust implementation of the canonical Java `MobilityData/gtfs-validator`.
 - Workspace crates live in `crates/`; core logic is in `gtfs_validator_core`, deterministic feed facts live in `gtfs_validator_profile`, and CLI, MCP, web, WASM, Python, and GUI are adapters.
 - Benchmark inputs and the Java baseline live in `benchmark-feeds/` (`gtfs-validator.jar`).
 


### PR DESCRIPTION
[Issue GTF-15 on Linear](https://linear.app/abasis/issue/GTF-15/use-proper-mention-of-the-java-validator-in-agentsmd)
The changelog:
 - Instead of referring to a local development environment's directory for the canonical GTFS validator written in Java, a reference to the GitHub repository is used with better wording