### PR TITLE
Solution for GTF-16: the published crates on crates.io don't have readme

### DIFF
--- a/crates/gtfs_model/Cargo.toml
+++ b/crates/gtfs_model/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 description = "Data models for GTFS (General Transit Feed Specification)"
 repository = "https://github.com/abasis-ltd/gtfs.guru"
 homepage = "https://github.com/abasis-ltd/gtfs.guru"
+readme = "README.md"
+keywords = ["gtfs", "transit", "gis", "public-transport"]
+categories = ["data-structures", "science"]
 [dependencies]
 chrono = { workspace = true }
 compact_str = { version = "0.9.0", features = ["serde"] }

--- a/crates/gtfs_model/README.md
+++ b/crates/gtfs_model/README.md
@@ -1,0 +1,24 @@
+# GTFS Guru Model
+
+[![Crates.io](https://img.shields.io/crates/v/gtfs-guru-model.svg)](https://crates.io/crates/gtfs-guru-model)
+
+Data models for GTFS (General Transit Feed Specification): the shared types
+(`RouteType`, `GtfsDate`, `ExceptionType`, `ServiceAvailability`, `StringId`,
+...) used across [GTFS Guru](https://github.com/abasis-ltd/gtfs.guru), a fast
+native GTFS validator written in Rust.
+
+This crate has no validation logic of its own — see
+[`gtfs-guru-core`](https://crates.io/crates/gtfs-guru-core) for that. It
+exists so the model types can be shared between the core validator, the
+report/profile crates, and downstream tools without pulling in the rest of
+the validation engine.
+
+## Installation
+
+```bash
+cargo add gtfs-guru-model
+```
+
+## License
+
+Apache-2.0

--- a/crates/gtfs_validator_cli/Cargo.toml
+++ b/crates/gtfs_validator_cli/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 description = "Command-line interface for GTFS Guru validator"
 repository = "https://github.com/abasis-ltd/gtfs.guru"
 homepage = "https://github.com/abasis-ltd/gtfs.guru"
+readme = "README.md"
+keywords = ["gtfs", "transit", "validator", "cli"]
+categories = ["command-line-utilities"]
 [[bin]]
 name = "gtfs-guru"
 path = "src/main.rs"

--- a/crates/gtfs_validator_cli/README.md
+++ b/crates/gtfs_validator_cli/README.md
@@ -1,0 +1,35 @@
+# GTFS Guru
+
+[![Crates.io](https://img.shields.io/crates/v/gtfs-guru.svg)](https://crates.io/crates/gtfs-guru)
+
+Command-line interface for the [GTFS Guru](https://github.com/abasis-ltd/gtfs.guru)
+validator — a fast, native replacement for the Java
+[`MobilityData/gtfs-validator`](https://github.com/MobilityData/gtfs-validator),
+with no JVM startup cost.
+
+## Installation
+
+```bash
+cargo install gtfs-guru
+```
+
+Prebuilt binaries for macOS, Windows, and Linux are also published on the
+[releases page](https://github.com/abasis-ltd/gtfs.guru/releases/latest).
+
+## Usage
+
+```bash
+gtfs-guru --input path/to/gtfs.zip
+```
+
+Run `gtfs-guru --help` for the full option list, including JSON/HTML/SARIF
+report output, `--country-code`, `--date`, and `--fail-on` thresholds for CI
+use, plus the `diff`, `profile`, and `explain` subcommands.
+
+See the [main project README](https://github.com/abasis-ltd/gtfs.guru) for
+the full feature set, including the desktop app, Python bindings, and Web
+API.
+
+## License
+
+Apache-2.0

--- a/crates/gtfs_validator_core/Cargo.toml
+++ b/crates/gtfs_validator_core/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 description = "Core validation logic for GTFS Guru"
 repository = "https://github.com/abasis-ltd/gtfs.guru"
 homepage = "https://github.com/abasis-ltd/gtfs.guru"
+readme = "README.md"
+keywords = ["gtfs", "transit", "validator", "gis"]
+categories = ["parsing", "science"]
 [features]
 default = ["parallel"]
 parallel = ["rayon"]

--- a/crates/gtfs_validator_core/README.md
+++ b/crates/gtfs_validator_core/README.md
@@ -1,0 +1,24 @@
+# GTFS Guru Core
+
+[![Crates.io](https://img.shields.io/crates/v/gtfs-guru-core.svg)](https://crates.io/crates/gtfs-guru-core)
+
+Core validation logic for [GTFS Guru](https://github.com/abasis-ltd/gtfs.guru)
+— a fast, native, multi-platform GTFS validator. This crate loads and parses
+a GTFS feed (`GtfsFeed`, `GtfsInput`), runs its validators, and produces
+`ValidationNotice`s through the notice/`NoticeContainer` machinery, with an
+optional `parallel` feature (enabled by default) for multi-threaded loading
+and validation via `rayon`.
+
+This is the engine used by the [`gtfs-guru`](https://crates.io/crates/gtfs-guru)
+CLI, the desktop app, the Python bindings, and the WebAssembly build; use it
+directly if you want to embed GTFS validation in your own Rust project.
+
+## Installation
+
+```bash
+cargo add gtfs-guru-core
+```
+
+## License
+
+Apache-2.0

--- a/crates/gtfs_validator_gui/Cargo.toml
+++ b/crates/gtfs_validator_gui/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "gtfs-guru-gui"
 version = "1.0.0"
+# Not published: this is the Tauri desktop app, distributed via GitHub
+# releases, not something anyone `cargo add`s.
+publish = false
 edition = "2021"
 license = "Apache-2.0"
 description = "Desktop GUI for GTFS Validator"

--- a/crates/gtfs_validator_mcp/Cargo.toml
+++ b/crates/gtfs_validator_mcp/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 description = "Validation-focused MCP server for GTFS Guru"
 repository = "https://github.com/abasis-ltd/gtfs.guru"
 homepage = "https://github.com/abasis-ltd/gtfs.guru"
+readme = "README.md"
+keywords = ["gtfs", "transit", "mcp", "validator"]
+categories = ["command-line-utilities"]
 
 [[bin]]
 name = "gtfs-guru-mcp"

--- a/crates/gtfs_validator_mcp/README.md
+++ b/crates/gtfs_validator_mcp/README.md
@@ -1,0 +1,29 @@
+# GTFS Guru MCP
+
+[![Crates.io](https://img.shields.io/crates/v/gtfs-guru-mcp.svg)](https://crates.io/crates/gtfs-guru-mcp)
+
+A read-only, validation-focused [MCP](https://modelcontextprotocol.io) server
+for [GTFS Guru](https://github.com/abasis-ltd/gtfs.guru), letting an LLM
+client validate GTFS feeds and inspect the resulting notices, profile facts,
+and explanations directly.
+
+## Installation
+
+```bash
+cargo install gtfs-guru-mcp
+```
+
+## Usage
+
+```bash
+gtfs-guru-mcp --transport stdio --allow-dir /path/to/gtfs/feeds
+```
+
+Point your MCP client (Claude Desktop, Claude Code, etc.) at the resulting
+stdio server, or run `--transport http` with `--bind` for HTTP access
+(requires a bearer token). Run `gtfs-guru-mcp --help` for the full option
+list.
+
+## License
+
+Apache-2.0

--- a/crates/gtfs_validator_profile/Cargo.toml
+++ b/crates/gtfs_validator_profile/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 description = "Deterministic feed profiles and explanations for GTFS Guru"
 repository = "https://github.com/abasis-ltd/gtfs.guru"
 homepage = "https://github.com/abasis-ltd/gtfs.guru"
+readme = "README.md"
+keywords = ["gtfs", "transit", "validator", "profile"]
+categories = ["parsing", "science"]
 
 [dependencies]
 chrono = { workspace = true }

--- a/crates/gtfs_validator_profile/README.md
+++ b/crates/gtfs_validator_profile/README.md
@@ -1,0 +1,20 @@
+# GTFS Guru Profile
+
+[![Crates.io](https://img.shields.io/crates/v/gtfs-guru-profile.svg)](https://crates.io/crates/gtfs-guru-profile)
+
+Deterministic, model-friendly facts derived from a parsed GTFS feed, for
+[GTFS Guru](https://github.com/abasis-ltd/gtfs.guru). The types in this
+crate deliberately contain no generated prose and make no provider-specific
+LLM calls — the CLI, MCP server, web API, and any hosted product can share
+the same computed facts and explanations without risking different
+calculations between them.
+
+## Installation
+
+```bash
+cargo add gtfs-guru-profile
+```
+
+## License
+
+Apache-2.0

--- a/crates/gtfs_validator_python/Cargo.toml
+++ b/crates/gtfs_validator_python/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "gtfs-guru-python"
 version = "1.0.0"
+# Not published: distributed via PyPI as `gtfs-guru`, not crates.io.
+publish = false
 edition.workspace = true
 license.workspace = true
 description = "Fast GTFS validator written in Rust"

--- a/crates/gtfs_validator_report/Cargo.toml
+++ b/crates/gtfs_validator_report/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 description = "Reporting structures for GTFS Guru validator"
 repository = "https://github.com/abasis-ltd/gtfs.guru"
 homepage = "https://github.com/abasis-ltd/gtfs.guru"
+readme = "README.md"
+keywords = ["gtfs", "transit", "validator", "report"]
+categories = ["encoding"]
 [dependencies]
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/crates/gtfs_validator_report/README.md
+++ b/crates/gtfs_validator_report/README.md
@@ -1,0 +1,20 @@
+# GTFS Guru Report
+
+[![Crates.io](https://img.shields.io/crates/v/gtfs-guru-report.svg)](https://crates.io/crates/gtfs-guru-report)
+
+Reporting structures for the [GTFS Guru](https://github.com/abasis-ltd/gtfs.guru)
+validator: turns the notices produced by
+[`gtfs-guru-core`](https://crates.io/crates/gtfs-guru-core) into a
+`ValidationReport`, with JSON, HTML, and SARIF output support (the same JSON
+report shape as the Java `MobilityData/gtfs-validator`, for drop-in CI
+compatibility).
+
+## Installation
+
+```bash
+cargo add gtfs-guru-report
+```
+
+## License
+
+Apache-2.0

--- a/crates/gtfs_validator_wasm/Cargo.toml
+++ b/crates/gtfs_validator_wasm/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "gtfs-guru-wasm"
 version = "1.0.0"
+# Not published: consumed via npm/wasm-bindgen, not crates.io.
+publish = false
 edition = "2021"
 license = "Apache-2.0"
 description = "GTFS validator compiled to WebAssembly for browser-based validation"


### PR DESCRIPTION
[The GTF-16 issue in Linear](https://linear.app/abasis/issue/GTF-16/the-published-crates-on-cratesio-dont-have-readme)
The changelog:
 - For the `gtfs_module`, `gtfs_validator_cli`, `gtfs_validator_core`, `gtfs_validator_mcp`, `gtfs_validator_profile`, `gtfs_validator_report` crates, references to `README.md` and keywords & categories were added in Cargo.toml
 - For the `gtfs_validator_gui`, `gtfs_validator_python`, `gtfs_validator_wasm` crates, the `publish = false` flag was added in `Cargo.toml` because they are not supposed to be installed with cargo