### PR TITLE
Make notice sample selection deterministic across runs

### DIFF
--- a/crates/gtfs_validator_core/src/feed.rs
+++ b/crates/gtfs_validator_core/src/feed.rs
@@ -147,6 +147,21 @@ impl GtfsFeed {
         self.stop_times_by_trip = Self::build_stop_times_index(&self.stop_times);
     }
 
+    /// Trip groups from `stop_times_by_trip` ordered by each trip's first
+    /// stop_times row. `HashMap` iteration order and `StringId` values both
+    /// vary between runs, so notice-emitting fan-ins must use this instead:
+    /// the per-group sample cap keeps the first N notices pushed, and a stable
+    /// order keeps that subset (and report bytes) identical across runs.
+    pub fn stop_times_by_trip_ordered(&self) -> Vec<(gtfs_guru_model::StringId, &[usize])> {
+        let mut groups: Vec<(gtfs_guru_model::StringId, &[usize])> = self
+            .stop_times_by_trip
+            .iter()
+            .map(|(trip_id, indices)| (*trip_id, indices.as_slice()))
+            .collect();
+        groups.sort_unstable_by_key(|(_, indices)| indices.iter().copied().min());
+        groups
+    }
+
     pub fn table_status(&self, file_name: &str) -> TableStatus {
         self.table_statuses
             .get(file_name)

--- a/crates/gtfs_validator_core/src/rules/duplicate_stop_sequence.rs
+++ b/crates/gtfs_validator_core/src/rules/duplicate_stop_sequence.rs
@@ -14,12 +14,13 @@ impl Validator for DuplicateStopSequenceValidator {
     }
 
     fn validate(&self, feed: &GtfsFeed, notices: &mut NoticeContainer) {
+        let trip_groups = feed.stop_times_by_trip_ordered();
+
         #[cfg(feature = "parallel")]
         {
             use rayon::prelude::*;
             let ctx = crate::ValidationContextState::capture();
-            let new_notices: Vec<ValidationNotice> = feed
-                .stop_times_by_trip
+            let new_notices: Vec<ValidationNotice> = trip_groups
                 .par_iter()
                 .flat_map(|(trip_id, indices)| {
                     let _guards = ctx.apply();
@@ -34,8 +35,8 @@ impl Validator for DuplicateStopSequenceValidator {
 
         #[cfg(not(feature = "parallel"))]
         {
-            for (trip_id, indices) in &feed.stop_times_by_trip {
-                let trip_notices = Self::check_trip(feed, *trip_id, indices);
+            for (trip_id, indices) in trip_groups {
+                let trip_notices = Self::check_trip(feed, trip_id, indices);
                 for notice in trip_notices {
                     notices.push(notice);
                 }

--- a/crates/gtfs_validator_core/src/rules/missing_trip_edge.rs
+++ b/crates/gtfs_validator_core/src/rules/missing_trip_edge.rs
@@ -11,13 +11,14 @@ impl Validator for MissingTripEdgeValidator {
     }
 
     fn validate(&self, feed: &GtfsFeed, notices: &mut NoticeContainer) {
+        let trip_groups = feed.stop_times_by_trip_ordered();
+
         #[cfg(feature = "parallel")]
         {
-            #[cfg(feature = "parallel")]
             let results: Vec<NoticeContainer> = {
                 use rayon::prelude::*;
                 let ctx = crate::ValidationContextState::capture();
-                feed.stop_times_by_trip
+                trip_groups
                     .par_iter()
                     .map(|(trip_id, stop_time_indices)| {
                         let _guards = ctx.apply();
@@ -34,8 +35,8 @@ impl Validator for MissingTripEdgeValidator {
         #[cfg(not(feature = "parallel"))]
         {
             // Use pre-built index - indices are already sorted by stop_sequence
-            for (trip_id, indices) in &feed.stop_times_by_trip {
-                let result = Self::check_trip(feed, *trip_id, indices);
+            for (trip_id, indices) in trip_groups {
+                let result = Self::check_trip(feed, trip_id, indices);
                 notices.merge(result);
             }
         }

--- a/crates/gtfs_validator_core/src/rules/overlapping_pickup_drop_off_zone.rs
+++ b/crates/gtfs_validator_core/src/rules/overlapping_pickup_drop_off_zone.rs
@@ -22,18 +22,27 @@ impl Validator for OverlappingPickupDropOffZoneValidator {
         }
         let locations = feed.locations.as_ref();
 
-        // Collect stops by trip (sequential grouping is fine as O(N))
+        // Collect stops by trip (sequential grouping is fine as O(N)), keeping
+        // trip groups in first-appearance order: iterating the HashMap would
+        // emit notices in a run-dependent order and the capped sample would
+        // keep a different subset each run.
         let mut by_trip: HashMap<gtfs_guru_model::StringId, Vec<(u64, &StopTime)>> = HashMap::new();
+        let mut trip_order: Vec<gtfs_guru_model::StringId> = Vec::new();
         for (index, stop_time) in feed.stop_times.rows.iter().enumerate() {
             let row_number = feed.stop_times.row_number(index);
             let trip_id = stop_time.trip_id;
             if trip_id.0 == 0 {
                 continue;
             }
-            by_trip
-                .entry(trip_id)
-                .or_default()
-                .push((row_number, stop_time));
+            match by_trip.entry(trip_id) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    entry.get_mut().push((row_number, stop_time))
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    trip_order.push(trip_id);
+                    entry.insert(vec![(row_number, stop_time)]);
+                }
+            }
         }
 
         // Parallelize validation of trips
@@ -41,11 +50,11 @@ impl Validator for OverlappingPickupDropOffZoneValidator {
         let results: Vec<NoticeContainer> = {
             use rayon::prelude::*;
             let ctx = crate::ValidationContextState::capture();
-            by_trip
+            trip_order
                 .par_iter()
-                .map(|(_, stop_times)| {
+                .map(|trip_id| {
                     let _guards = ctx.apply();
-                    validate_trip(stop_times, locations, feed)
+                    validate_trip(&by_trip[trip_id], locations, feed)
                 })
                 .collect()
         };
@@ -59,8 +68,8 @@ impl Validator for OverlappingPickupDropOffZoneValidator {
 
         #[cfg(not(feature = "parallel"))]
         {
-            for stop_times in by_trip.values() {
-                let result = validate_trip(stop_times, locations, feed);
+            for trip_id in &trip_order {
+                let result = validate_trip(&by_trip[trip_id], locations, feed);
                 notices.merge(result);
             }
         }

--- a/crates/gtfs_validator_core/src/rules/service_windows_v8.rs
+++ b/crates/gtfs_validator_core/src/rules/service_windows_v8.rs
@@ -94,11 +94,19 @@ fn validate_feed_window(
     active_dates: &BTreeMap<StringId, BTreeSet<NaiveDate>>,
     notices: &mut NoticeContainer,
 ) {
-    let service_ids: BTreeSet<_> = feed
+    // First-appearance order over trips.txt: `StringId` values are assigned by
+    // racing parallel CSV workers, so ordering by them (e.g. via a BTreeSet)
+    // varies between runs and the capped notice sample keeps a different
+    // subset each run.
+    let mut seen_service_ids = HashSet::new();
+    let service_ids: Vec<_> = feed
         .trips
         .rows
         .iter()
-        .filter_map(|trip| (trip.service_id.0 != 0).then_some(trip.service_id))
+        .filter_map(|trip| {
+            (trip.service_id.0 != 0 && seen_service_ids.insert(trip.service_id))
+                .then_some(trip.service_id)
+        })
         .collect();
     let service_windows: Vec<_> = service_ids
         .iter()

--- a/crates/gtfs_validator_core/src/rules/shape_to_stop_matching.rs
+++ b/crates/gtfs_validator_core/src/rules/shape_to_stop_matching.rs
@@ -79,21 +79,38 @@ impl Validator for ShapeToStopMatchingValidator {
             trips_by_shape.entry(shape_id).or_default().push(trip);
         }
 
+        // Group shapes by id, keeping groups in first-appearance order of the
+        // shape_id in shapes.txt. Iterating the HashMap directly would make
+        // the notice order (and the capped sample subset) vary between runs.
         let mut shapes_by_id: HashMap<gtfs_guru_model::StringId, Vec<&gtfs_guru_model::Shape>> =
             HashMap::new();
+        let mut shape_order: Vec<gtfs_guru_model::StringId> = Vec::new();
         for shape in &shapes.rows {
             let shape_id = shape.shape_id;
             if shape_id.0 == 0 {
                 continue;
             }
-            shapes_by_id.entry(shape_id).or_default().push(shape);
+            match shapes_by_id.entry(shape_id) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    entry.get_mut().push(shape)
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    shape_order.push(shape_id);
+                    entry.insert(vec![shape]);
+                }
+            }
         }
+        let shape_groups: Vec<(gtfs_guru_model::StringId, Vec<&gtfs_guru_model::Shape>)> =
+            shape_order
+                .into_iter()
+                .filter_map(|shape_id| Some((shape_id, shapes_by_id.remove(&shape_id)?)))
+                .collect();
 
         #[cfg(feature = "parallel")]
         {
             use rayon::prelude::*;
             let ctx = crate::ValidationContextState::capture();
-            let results: Vec<NoticeContainer> = shapes_by_id
+            let results: Vec<NoticeContainer> = shape_groups
                 .into_par_iter()
                 .filter_map(|(shape_id, shape_points_raw)| {
                     let _guards = ctx.apply();
@@ -185,7 +202,7 @@ impl Validator for ShapeToStopMatchingValidator {
         #[cfg(not(feature = "parallel"))]
         {
             let matcher = StopToShapeMatcher::default();
-            for (shape_id, shape_points_raw) in shapes_by_id {
+            for (shape_id, shape_points_raw) in shape_groups {
                 let trips = match trips_by_shape.get(&shape_id) {
                     Some(trips) => trips,
                     None => continue,

--- a/crates/gtfs_validator_core/src/rules/shape_usage.rs
+++ b/crates/gtfs_validator_core/src/rules/shape_usage.rs
@@ -61,10 +61,15 @@ impl Validator for ShapeUsageValidator {
                     },
                 );
 
-            // 3. Generate notices
-            let results: Vec<ValidationNotice> = shapes_map
-                .into_par_iter()
+            // 3. Generate notices, ordered by first row: HashMap iteration
+            // order varies between runs, and with it the capped notice sample.
+            let mut unused: Vec<(gtfs_guru_model::StringId, u64)> = shapes_map
+                .into_iter()
                 .filter(|(shape_id, _)| !used_shapes.contains(shape_id))
+                .collect();
+            unused.sort_unstable_by_key(|(_, row_number)| *row_number);
+            let results: Vec<ValidationNotice> = unused
+                .into_par_iter()
                 .map(|(shape_id, row_number)| {
                     let shape_id_value = feed.pool.resolve(shape_id);
                     let mut notice = ValidationNotice::new(

--- a/crates/gtfs_validator_core/src/rules/stop_time_increasing_distance.rs
+++ b/crates/gtfs_validator_core/src/rules/stop_time_increasing_distance.rs
@@ -32,13 +32,14 @@ impl Validator for StopTimeIncreasingDistanceValidator {
 
         // Let's use `feed.stop_times_by_trip` which is efficient.
 
+        let trip_groups = feed.stop_times_by_trip_ordered();
+
         #[cfg(feature = "parallel")]
         {
-            #[cfg(feature = "parallel")]
             let results: Vec<NoticeContainer> = {
                 use rayon::prelude::*;
                 let ctx = crate::ValidationContextState::capture();
-                feed.stop_times_by_trip
+                trip_groups
                     .par_iter()
                     .map(|(trip_id, stop_time_indices)| {
                         let _guards = ctx.apply();
@@ -55,8 +56,8 @@ impl Validator for StopTimeIncreasingDistanceValidator {
 
         #[cfg(not(feature = "parallel"))]
         {
-            for (trip_id, indices) in &feed.stop_times_by_trip {
-                let result = check_trip(*trip_id, indices, feed);
+            for (trip_id, indices) in trip_groups {
+                let result = check_trip(trip_id, indices, feed);
                 notices.merge(result);
             }
         }

--- a/crates/gtfs_validator_core/src/rules/stop_time_travel_speed.rs
+++ b/crates/gtfs_validator_core/src/rules/stop_time_travel_speed.rs
@@ -70,6 +70,7 @@ impl Validator for StopTimeTravelSpeedValidator {
         let mut trips_by_pattern: HashMap<u64, Vec<gtfs_guru_model::StringId>> = HashMap::new();
         let mut pattern_insertion_order: Vec<u64> = Vec::new();
         let mut seen_patterns = HashSet::new();
+        let mut string_hashes: HashMap<gtfs_guru_model::StringId, u64> = HashMap::new();
         for trip_id in trip_ids_java_order {
             let indices = match feed.stop_times_by_trip.get(&trip_id) {
                 Some(indices) => indices,
@@ -83,7 +84,7 @@ impl Validator for StopTimeTravelSpeedValidator {
             if route_id.0 == 0 || !context.routes_by_id.contains_key(&route_id) {
                 continue;
             }
-            let fingerprint = Self::trip_fingerprint(trip, indices, feed);
+            let fingerprint = Self::trip_fingerprint(trip, indices, feed, &mut string_hashes);
             if seen_patterns.insert(fingerprint) {
                 pattern_insertion_order.push(fingerprint);
             }
@@ -249,13 +250,35 @@ impl StopTimeTravelSpeedValidator {
         notices
     }
 
-    fn trip_fingerprint(trip: &gtfs_guru_model::Trip, indices: &[usize], feed: &GtfsFeed) -> u64 {
+    /// Hash of the interned string behind `id`, cached per id. `StringId`
+    /// values are assigned by racing parallel CSV workers and differ between
+    /// runs, so fingerprints must hash the resolved strings instead — the
+    /// pattern iteration order (and thus the capped notice sample) depends on
+    /// these fingerprints.
+    fn string_id_hash(
+        id: gtfs_guru_model::StringId,
+        feed: &GtfsFeed,
+        cache: &mut HashMap<gtfs_guru_model::StringId, u64>,
+    ) -> u64 {
+        *cache.entry(id).or_insert_with(|| {
+            let mut hasher = DefaultHasher::new();
+            feed.pool.resolve(id).hash(&mut hasher);
+            hasher.finish()
+        })
+    }
+
+    fn trip_fingerprint(
+        trip: &gtfs_guru_model::Trip,
+        indices: &[usize],
+        feed: &GtfsFeed,
+        string_hashes: &mut HashMap<gtfs_guru_model::StringId, u64>,
+    ) -> u64 {
         let mut hasher = DefaultHasher::new();
-        trip.route_id.hash(&mut hasher);
+        Self::string_id_hash(trip.route_id, feed, string_hashes).hash(&mut hasher);
         indices.len().hash(&mut hasher);
         for &index in indices {
             let stop_time = &feed.stop_times.rows[index];
-            stop_time.stop_id.hash(&mut hasher);
+            Self::string_id_hash(stop_time.stop_id, feed, string_hashes).hash(&mut hasher);
             stop_time
                 .arrival_time
                 .map(|time| time.total_seconds())

--- a/crates/gtfs_validator_core/src/rules/stop_times_time.rs
+++ b/crates/gtfs_validator_core/src/rules/stop_times_time.rs
@@ -18,7 +18,7 @@ impl Validator for StopTimeArrivalAndDepartureTimeValidator {
     }
 
     fn validate(&self, feed: &GtfsFeed, notices: &mut NoticeContainer) {
-        for (trip_id, indices) in &feed.stop_times_by_trip {
+        for (trip_id, indices) in feed.stop_times_by_trip_ordered() {
             let mut previous_departure: Option<(gtfs_guru_model::GtfsTime, u64)> = None;
             for &index in indices {
                 let stop_time = &feed.stop_times.rows[index];
@@ -26,7 +26,7 @@ impl Validator for StopTimeArrivalAndDepartureTimeValidator {
                 let has_arrival = stop_time.arrival_time.is_some();
                 let has_departure = stop_time.departure_time.is_some();
                 if has_arrival != has_departure {
-                    let trip_id = feed.pool.resolve(*trip_id);
+                    let trip_id = feed.pool.resolve(trip_id);
                     let specified_field = if has_arrival {
                         "arrival_time"
                     } else {
@@ -81,7 +81,7 @@ impl Validator for StopTimeArrivalAndDepartureTimeValidator {
                     (stop_time.arrival_time, previous_departure)
                 {
                     if arrival.total_seconds() < prev_departure.total_seconds() {
-                        let trip_id = feed.pool.resolve(*trip_id);
+                        let trip_id = feed.pool.resolve(trip_id);
                         let mut notice = ValidationNotice::new(
                             CODE_STOP_TIME_WITH_ARRIVAL_BEFORE_PREVIOUS_DEPARTURE_TIME,
                             NoticeSeverity::Error,

--- a/crates/gtfs_validator_core/src/rules/v8_data_quality.rs
+++ b/crates/gtfs_validator_core/src/rules/v8_data_quality.rs
@@ -72,8 +72,12 @@ impl Validator for UnsortedStopTimesValidator {
             unsorted: bool,
         }
 
+        // `trip_order` keeps first-appearance order: iterating the HashMap
+        // would emit notices in a run-dependent order and the capped sample
+        // would keep a different subset each run.
         fn merge_group(
             stats_by_trip: &mut HashMap<StringId, Stats>,
+            trip_order: &mut Vec<StringId>,
             trip_id: StringId,
             group: Stats,
         ) {
@@ -83,17 +87,19 @@ impl Validator for UnsortedStopTimesValidator {
                 existing.max_row = existing.max_row.max(group.max_row);
                 existing.unsorted = true;
             } else {
+                trip_order.push(trip_id);
                 stats_by_trip.insert(trip_id, group);
             }
         }
 
         let mut stats_by_trip = HashMap::new();
+        let mut trip_order: Vec<StringId> = Vec::new();
         let mut current_trip = StringId(0);
         let mut current_stats = Stats::default();
         for (index, stop_time) in feed.stop_times.rows.iter().enumerate() {
             if stop_time.trip_id.0 == 0 {
                 if current_trip.0 != 0 {
-                    merge_group(&mut stats_by_trip, current_trip, current_stats);
+                    merge_group(&mut stats_by_trip, &mut trip_order, current_trip, current_stats);
                     current_trip = StringId(0);
                     current_stats = Stats::default();
                 }
@@ -101,7 +107,7 @@ impl Validator for UnsortedStopTimesValidator {
             }
             if stop_time.trip_id != current_trip {
                 if current_trip.0 != 0 {
-                    merge_group(&mut stats_by_trip, current_trip, current_stats);
+                    merge_group(&mut stats_by_trip, &mut trip_order, current_trip, current_stats);
                 }
                 current_trip = stop_time.trip_id;
                 current_stats = Stats::default();
@@ -124,9 +130,10 @@ impl Validator for UnsortedStopTimesValidator {
             current_stats.last_sequence = Some(stop_time.stop_sequence);
         }
         if current_trip.0 != 0 {
-            merge_group(&mut stats_by_trip, current_trip, current_stats);
+            merge_group(&mut stats_by_trip, &mut trip_order, current_trip, current_stats);
         }
-        for (trip_id, stats) in stats_by_trip {
+        for trip_id in trip_order {
+            let stats = &stats_by_trip[&trip_id];
             let span = stats.max_row.saturating_sub(stats.min_row) + 1;
             if !stats.unsorted && span <= stats.count {
                 continue;
@@ -263,12 +270,14 @@ impl Validator for TripWithShapeDistTraveledButNoShapeDistancesValidator {
             .enumerate()
             .map(|(index, trip)| (trip.trip_id, (index, trip)))
             .collect();
-        let mut first_distance_by_trip = HashMap::new();
+        // Vec of (trip, first row with a distance) in file order: iterating a
+        // HashMap here would emit notices in a run-dependent order and the
+        // capped sample would keep a different subset each run.
+        let mut seen_trips = std::collections::HashSet::new();
+        let mut first_distance_by_trip: Vec<(StringId, usize)> = Vec::new();
         for (index, stop_time) in feed.stop_times.rows.iter().enumerate() {
-            if stop_time.shape_dist_traveled.is_some() {
-                first_distance_by_trip
-                    .entry(stop_time.trip_id)
-                    .or_insert(index);
+            if stop_time.shape_dist_traveled.is_some() && seen_trips.insert(stop_time.trip_id) {
+                first_distance_by_trip.push((stop_time.trip_id, index));
             }
         }
         for (trip_id, first_with_distance) in first_distance_by_trip {


### PR DESCRIPTION
## Problem

Two runs of the same release binary on the same feed produced a different composition of `sampleNotices` (with identical `totalNotices`) for several rules: `fast_travel_between_consecutive_stops`, `fast_travel_between_far_stops`, `stop_too_far_from_shape`, `stops_match_shape_out_of_order`, `service_window_outside_feed_period`, `stop_too_far_from_shape_using_user_distance`, `trip_with_shape_dist_traveled_but_no_shape_distances`. The per-code sample cap (1000) keeps the first N notices pushed, but these rules emitted notices in a run-dependent order.

Three root causes:

1. **Nondeterministic `StringId` values.** `StringPool::intern` assigns ids from an atomic counter racing across parallel CSV workers, so anything ordered by the numeric id varied between runs (`service_windows_v8`'s `BTreeSet<StringId>`, `stop_time_travel_speed`'s pattern fingerprints which hashed raw ids).
2. **rayon fan-ins iterating a `HashMap`** (`shape_to_stop_matching`'s `shapes_by_id.into_par_iter()`, and the `stop_times_by_trip` consumers) inherit its per-run random iteration order.
3. **Sequential loops over `HashMap`s** (`unsorted_stop_times`, `trip_with_shape_dist_traveled_but_no_shape_distances`) — no parallelism involved at all.

## Fix

- New `GtfsFeed::stop_times_by_trip_ordered()` returns trip groups ordered by each trip's first stop_times row, independent of hash order and id values; `duplicate_stop_sequence`, `missing_trip_edge`, `stop_time_increasing_distance` and `stop_times_time` now use it.
- `stop_time_travel_speed` fingerprints hash the resolved strings (cached per id) instead of raw `StringId` values.
- `shape_to_stop_matching`, `overlapping_pickup_drop_off_zone`, `unsorted_stop_times` and `trip_with_shape_dist_traveled_but_no_shape_distances` iterate groups in first-appearance file order; `shape_usage` sorts unused shapes by row number.
- `service_windows_v8` collects service ids in trips.txt first-appearance order instead of sorting by numeric id.

The top-level `validators.par_iter().reduce(merge)` needed no change: rayon's reduce is order-preserving and the capped merge is associative.

## Verification

- Baseline reproduced the nondeterminism on `benchmark-feeds/il.zip` (6 codes differed between two runs; 2 of them lost different subsets under the cap).
- After the fix, two consecutive release runs on `il.zip` and `nl.zip` produce byte-identical `report.json` modulo runtime summary fields (`validatedAt`, `validationTimeSeconds`, `memoryUsageRecords`, `outputDirectory`).
- `cargo test -p gtfs-guru-core`: 382 tests pass.
- `cargo clippy -p gtfs-guru-core --all-targets`: clean.
- `scripts/ci_golden.sh`: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)