### PR TITLE
Harden zip caps, web uploads, and job admission after review

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -30,9 +30,9 @@ gtfs.guru {
         -Server
     }
 
-    # Request body size limit for GTFS uploads (500MB)
+    # Request body size limit for GTFS uploads (256 MiB, matches compose caps)
     request_body {
-        max_size 500MB
+        max_size 256MiB
     }
 
     # Access logs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,6 +1855,7 @@ dependencies = [
  "anyhow",
  "axum",
  "base64 0.22.1",
+ "futures-util",
  "gtfs-guru-core",
  "gtfs-guru-report",
  "include_dir",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,5 +64,8 @@ Out of scope:
   `POST /run-validator`. The endpoint returns 401 when the token is unset.
 - Set `POSTGRES_PASSWORD` and `UMAMI_SECRET`; Compose refuses to start without
   them.
+- Feeds given as a directory are read without following symlinks. A member that
+  is a symlink is not listed, and reading it by name fails as "not a file".
+  Point the validator at the real files if your feed is assembled from links.
 - Uploaded feeds are stored under `GTFS_VALIDATOR_WEB_BASE_DIR`.
   `GTFS_VALIDATOR_WEB_JOB_TTL_SECONDS` controls retention.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,13 +42,26 @@ Out of scope:
 
 - Do not add an unrestricted forwarding proxy in front of the service. Keep
   browser remote-feed requests on the guarded `/cors-proxy?url=...` endpoint.
+- Bind the app port to loopback (`127.0.0.1:3000:3000`) when a reverse proxy
+  terminates TLS. Docker `ports:` published to `0.0.0.0` bypass host firewalls
+  such as UFW.
 - Configure limits for your hardware:
+  `GTFS_VALIDATOR_MAX_MEMBER_BYTES`,
+  `GTFS_VALIDATOR_MAX_TOTAL_BYTES`,
   `GTFS_VALIDATOR_WEB_MAX_UPLOAD_BYTES`,
   `GTFS_VALIDATOR_WEB_MAX_CONCURRENT_JOBS`,
+  `GTFS_VALIDATOR_WEB_MAX_CONCURRENT_UPLOADS`,
   `GTFS_VALIDATOR_WEB_MAX_QUEUED_JOBS`,
+  `GTFS_VALIDATOR_WEB_MAX_CREATE_JOB_REQUESTS_PER_MINUTE`,
+  `GTFS_VALIDATOR_WEB_PROCESSING_TIMEOUT_SECONDS`,
   `GTFS_VALIDATOR_WEB_MAX_PROXY_BYTES`,
   `GTFS_VALIDATOR_WEB_MAX_CONCURRENT_PROXY_REQUESTS`, and
   `GTFS_VALIDATOR_WEB_MAX_PROXY_REQUESTS_PER_MINUTE`.
+  The 2 GiB Compose stack sets zip and upload caps well below the library
+  defaults (4 GiB per member / 8 GiB per archive), which are meant for the CLI
+  on larger hosts.
+- Set `GTFS_VALIDATOR_WEB_PUBSUB_TOKEN` if anything should call
+  `POST /run-validator`. The endpoint returns 401 when the token is unset.
 - Set `POSTGRES_PASSWORD` and `UMAMI_SECRET`; Compose refuses to start without
   them.
 - Uploaded feeds are stored under `GTFS_VALIDATOR_WEB_BASE_DIR`.

--- a/crates/gtfs_validator_core/src/feed.rs
+++ b/crates/gtfs_validator_core/src/feed.rs
@@ -403,6 +403,7 @@ impl GtfsFeed {
         let google = crate::validation_context::google_rules_enabled();
         let country = crate::validation_context::validation_country_code();
         let date = crate::validation_context::validation_date();
+        let notice_group_limit = crate::validation_context::notice_group_limit();
 
         struct ParallelLoader<'a> {
             reader: &'a GtfsInputReader,
@@ -411,6 +412,7 @@ impl GtfsFeed {
             google: bool,
             country: Option<String>,
             date: NaiveDate,
+            notice_group_limit: Option<usize>,
             pool: crate::StringPool,
             file_sizes: &'a HashMap<String, u64>,
             total_bytes: u64,
@@ -432,6 +434,8 @@ impl GtfsFeed {
                 let _g3 =
                     crate::validation_context::set_validation_country_code(self.country.clone());
                 let _g4 = crate::validation_context::set_validation_date(Some(self.date));
+                let _g5 =
+                    crate::validation_context::set_notice_group_limit(self.notice_group_limit);
 
                 let pool_for_intern = self.pool.clone();
                 let pool_for_resolve = self.pool.clone();
@@ -515,6 +519,7 @@ impl GtfsFeed {
             google,
             country,
             date,
+            notice_group_limit,
             pool: crate::StringPool::new(),
             file_sizes: &file_sizes,
             total_bytes,
@@ -691,6 +696,9 @@ impl GtfsFeed {
                                                         );
                                                         let _g4 = crate::validation_context::set_validation_date(
                                                             Some(loader.date),
+                                                        );
+                                                        let _g5 = crate::validation_context::set_notice_group_limit(
+                                                            loader.notice_group_limit,
                                                         );
                                                         let (locations, n4) = match reader
                                                             .read_optional_json::<GeoJsonFeatureCollection>(

--- a/crates/gtfs_validator_core/src/input.rs
+++ b/crates/gtfs_validator_core/src/input.rs
@@ -1097,16 +1097,12 @@ fn map_capped_read_error(
 ) -> GtfsInputError {
     match limit_kind(&err) {
         Some(LimitKind::Total) => archive_budget_exceeded(path, file_name, max_total_bytes()),
-        Some(LimitKind::Member) => {
-            member_too_large(path, file_name, cap.saturating_add(1), cap)
-        }
-        None => {
-            GtfsInputError::ZipFileIo {
-                path: path.to_path_buf(),
-                file: file_name.to_string(),
-                source: err,
-            }
-        }
+        Some(LimitKind::Member) => member_too_large(path, file_name, cap.saturating_add(1), cap),
+        None => GtfsInputError::ZipFileIo {
+            path: path.to_path_buf(),
+            file: file_name.to_string(),
+            source: err,
+        },
     }
 }
 
@@ -2217,7 +2213,8 @@ mod tests {
     #[test]
     fn csv_limit_io_error_preserves_the_sentinel() {
         let wrapped = csv::Error::from(limit_io_error(LimitKind::Total, "stops.txt", 32));
-        let recovered = csv_limit_io_error(&wrapped).expect("limit error must survive the csv wrap");
+        let recovered =
+            csv_limit_io_error(&wrapped).expect("limit error must survive the csv wrap");
         assert_eq!(limit_kind(&recovered), Some(LimitKind::Total));
 
         let unrelated = csv::Error::from(std::io::Error::other("disk gone"));

--- a/crates/gtfs_validator_core/src/input.rs
+++ b/crates/gtfs_validator_core/src/input.rs
@@ -1163,7 +1163,7 @@ fn limit_kind(err: &std::io::Error) -> Option<LimitKind> {
 
 /// Re-wrap the limit error a CSV reader swallowed, preserving the sentinel so
 /// the caller still recognises it by type.
-#[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+#[cfg(feature = "parallel")]
 fn csv_limit_io_error(err: &csv::Error) -> Option<std::io::Error> {
     let csv::ErrorKind::Io(io_err) = err.kind() else {
         return None;
@@ -2209,7 +2209,7 @@ mod tests {
         assert_eq!(limit_kind(&impostor), None);
     }
 
-    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    #[cfg(feature = "parallel")]
     #[test]
     fn csv_limit_io_error_preserves_the_sentinel() {
         let wrapped = csv::Error::from(limit_io_error(LimitKind::Total, "stops.txt", 32));

--- a/crates/gtfs_validator_core/src/input.rs
+++ b/crates/gtfs_validator_core/src/input.rs
@@ -192,7 +192,11 @@ impl GtfsInputReader {
                         source: err,
                     })?;
                     let path = entry.path();
-                    if path.is_file() {
+                    let file_type = entry.file_type().map_err(|err| GtfsInputError::Io {
+                        path: path.clone(),
+                        source: err,
+                    })?;
+                    if file_type.is_file() {
                         let name = entry.file_name().to_string_lossy().to_string();
                         let size = path
                             .metadata()
@@ -531,10 +535,18 @@ impl GtfsInputReader {
                 if zipped.size() > cap {
                     return Err(zip_member_too_large(path, file_name, zipped.size(), cap));
                 }
+                if zipped.size() > remaining_bytes.load(Ordering::Relaxed) {
+                    return Err(archive_budget_exceeded(path, file_name, max_total_bytes()));
+                }
                 let capped = CappedReader::new(zipped, path, file_name, cap, remaining_bytes);
                 let mut buf_reader = std::io::BufReader::with_capacity(1 << 20, capped);
-                skip_utf8_bom(&mut buf_reader)
-                    .map_err(|err| GtfsInputError::Csv(map_io_error(file_name, err)))?;
+                skip_utf8_bom(&mut buf_reader).map_err(|err| {
+                    if is_limit_io_error(&err) {
+                        map_capped_read_error(path, file_name, cap, err)
+                    } else {
+                        GtfsInputError::Csv(map_io_error(file_name, err))
+                    }
+                })?;
 
                 let mut csv_reader = csv::ReaderBuilder::new()
                     .has_headers(true)
@@ -544,7 +556,13 @@ impl GtfsInputReader {
 
                 let headers = csv_reader
                     .byte_headers()
-                    .map_err(|err| GtfsInputError::Csv(map_csv_error(file_name, None, err)))?
+                    .map_err(|err| {
+                        if let Some(io_err) = csv_limit_io_error(&err) {
+                            map_capped_read_error(path, file_name, cap, io_err)
+                        } else {
+                            GtfsInputError::Csv(map_csv_error(file_name, None, err))
+                        }
+                    })?
                     .clone();
                 let mut headers_for_errors = csv::StringRecord::new();
                 for field in headers.iter() {
@@ -575,6 +593,9 @@ impl GtfsInputReader {
                             }
                         }
                         Err(err) => {
+                            if let Some(io_err) = csv_limit_io_error(&err) {
+                                return Err(map_capped_read_error(path, file_name, cap, io_err));
+                            }
                             let parse_err =
                                 map_csv_error(file_name, Some(&headers_for_errors), err);
                             if tx.send(Msg::ScanError(parse_err)).is_err() {
@@ -694,37 +715,19 @@ impl GtfsInputReader {
     fn read_from_directory(&self, file_name: &str) -> Result<Vec<u8>, GtfsInputError> {
         let path = self.path.join(file_name);
         if path.exists() {
-            if !path.is_file() {
+            if !is_regular_file(&path) {
                 return Err(GtfsInputError::NotAFile(path));
             }
-            let mut file = File::open(&path).map_err(|err| GtfsInputError::Io {
-                path: path.clone(),
-                source: err,
-            })?;
-            let mut buffer = Vec::new();
-            file.read_to_end(&mut buffer)
-                .map_err(|err| GtfsInputError::Io { path, source: err })?;
-            return Ok(buffer);
+            return read_filesystem_file_capped(path, file_name, &self.remaining_bytes);
         }
 
         let Some(found_path) = find_case_insensitive_file(&self.path, file_name)? else {
             return Err(GtfsInputError::MissingFile(file_name.to_string()));
         };
-        if !found_path.is_file() {
+        if !is_regular_file(&found_path) {
             return Err(GtfsInputError::NotAFile(found_path));
         }
-
-        let mut file = File::open(&found_path).map_err(|err| GtfsInputError::Io {
-            path: found_path.clone(),
-            source: err,
-        })?;
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer)
-            .map_err(|err| GtfsInputError::Io {
-                path: found_path,
-                source: err,
-            })?;
-        Ok(buffer)
+        read_filesystem_file_capped(found_path, file_name, &self.remaining_bytes)
     }
 
     fn read_from_zip(&self, file_name: &str) -> Result<Vec<u8>, GtfsInputError> {
@@ -1007,9 +1010,10 @@ fn charge_archive_budget(budget: &AtomicU64, amount: u64) -> Result<(), ()> {
 /// [`max_member_bytes`] for it or to push the archive total past
 /// [`max_total_bytes`]. Both the declared uncompressed size and the actual
 /// number of decompressed bytes are checked, so a lying zip header cannot slip
-/// past the cap.
+/// past the cap. The archive budget is charged as bytes stream out, so parallel
+/// member reads cannot each allocate a full member before any of them debit.
 fn read_zip_member_capped(
-    mut zipped: zip::read::ZipFile<'_>,
+    zipped: zip::read::ZipFile<'_>,
     path: &Path,
     file_name: &str,
     budget: &AtomicU64,
@@ -1019,45 +1023,95 @@ fn read_zip_member_capped(
     if zipped.size() > cap {
         return Err(zip_member_too_large(path, file_name, zipped.size(), cap));
     }
-    // Cheap early-out: refuse to even start reading a member whose declared size
-    // already blows the remaining archive budget.
     if zipped.size() > budget.load(Ordering::Relaxed) {
         return Err(archive_budget_exceeded(path, file_name, total_cap));
     }
+    read_capped_to_vec(zipped, path, file_name, cap, budget)
+}
 
+fn read_filesystem_file_capped(
+    path: PathBuf,
+    file_name: &str,
+    budget: &AtomicU64,
+) -> Result<Vec<u8>, GtfsInputError> {
+    let cap = max_member_bytes();
+    let total_cap = max_total_bytes();
+    let declared = std::fs::metadata(&path)
+        .map_err(|err| GtfsInputError::Io {
+            path: path.clone(),
+            source: err,
+        })?
+        .len();
+    if declared > cap {
+        return Err(zip_member_too_large(&path, file_name, declared, cap));
+    }
+    if declared > budget.load(Ordering::Relaxed) {
+        return Err(archive_budget_exceeded(&path, file_name, total_cap));
+    }
+    let file = File::open(&path).map_err(|err| GtfsInputError::Io {
+        path: path.clone(),
+        source: err,
+    })?;
+    read_capped_to_vec(file, &path, file_name, cap, budget)
+}
+
+fn read_capped_to_vec<R: Read>(
+    reader: R,
+    path: &Path,
+    file_name: &str,
+    cap: u64,
+    budget: &AtomicU64,
+) -> Result<Vec<u8>, GtfsInputError> {
+    let mut capped = CappedReader::new(reader, path, file_name, cap, budget);
     let mut buffer = Vec::new();
-    // Read at most cap + 1 bytes so an under-reported header is still caught.
-    zipped
-        .by_ref()
-        .take(cap + 1)
+    capped
         .read_to_end(&mut buffer)
-        .map_err(|err| GtfsInputError::ZipFileIo {
+        .map_err(|err| map_capped_read_error(path, file_name, cap, err))?;
+    Ok(buffer)
+}
+
+fn map_capped_read_error(
+    path: &Path,
+    file_name: &str,
+    cap: u64,
+    err: std::io::Error,
+) -> GtfsInputError {
+    if is_limit_io_error(&err) {
+        if err.to_string().contains("total decompression limit") {
+            archive_budget_exceeded(path, file_name, max_total_bytes())
+        } else {
+            zip_member_too_large(path, file_name, cap.saturating_add(1), cap)
+        }
+    } else {
+        GtfsInputError::ZipFileIo {
             path: path.to_path_buf(),
             file: file_name.to_string(),
             source: err,
-        })?;
-    if buffer.len() as u64 > cap {
-        return Err(zip_member_too_large(
-            path,
-            file_name,
-            buffer.len() as u64,
-            cap,
-        ));
+        }
     }
-    charge_archive_budget(budget, buffer.len() as u64)
-        .map_err(|()| archive_budget_exceeded(path, file_name, total_cap))?;
-    Ok(buffer)
+}
+
+fn is_limit_io_error(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::InvalidData
+        && (err.to_string().contains("per-file limit")
+            || err.to_string().contains("total decompression limit"))
+}
+
+fn csv_limit_io_error(err: &csv::Error) -> Option<std::io::Error> {
+    match err.kind() {
+        csv::ErrorKind::Io(io_err) if is_limit_io_error(io_err) => {
+            Some(std::io::Error::new(io_err.kind(), io_err.to_string()))
+        }
+        _ => None,
+    }
 }
 
 /// A `Read` adapter that enforces the per-member and archive-wide decompression
 /// caps as bytes stream out of a zip member. The streaming CSV reader never
 /// buffers a whole member, so without this a large member would be decompressed
 /// past the cap one batch at a time. On overflow it yields an
-/// `InvalidData` io error, which the streaming producer surfaces as a CSV error.
-///
-/// Only the streaming reader uses this, and that path is `parallel`-only, so
-/// the single-threaded build (notably wasm32) leaves it out entirely.
-#[cfg(feature = "parallel")]
+/// `InvalidData` io error. Reads are sized so a lying header cannot inflate
+/// more than one extra byte past the cap.
 struct CappedReader<'a, R> {
     inner: R,
     file_name: String,
@@ -1067,7 +1121,6 @@ struct CappedReader<'a, R> {
     budget: &'a AtomicU64,
 }
 
-#[cfg(feature = "parallel")]
 impl<'a, R> CappedReader<'a, R> {
     fn new(
         inner: R,
@@ -1087,10 +1140,18 @@ impl<'a, R> CappedReader<'a, R> {
     }
 }
 
-#[cfg(feature = "parallel")]
 impl<R: Read> Read for CappedReader<'_, R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let n = self.inner.read(buf)?;
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        // Read at most remaining+1 so an exact-sized member still reaches EOF,
+        // while one extra decompressed byte is enough to reject a lying header.
+        let max_read = match self.member_remaining.checked_add(1) {
+            Some(plus_one) => plus_one.min(buf.len() as u64) as usize,
+            None => buf.len(),
+        };
+        let n = self.inner.read(&mut buf[..max_read])?;
         if n == 0 {
             return Ok(0);
         }
@@ -1160,6 +1221,12 @@ fn locate_zip_member<R: Read + Seek>(
     Ok(ci_index)
 }
 
+fn is_regular_file(path: &Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .map(|meta| meta.file_type().is_file())
+        .unwrap_or(false)
+}
+
 fn list_files_in_directory(path: &Path) -> Result<Vec<String>, GtfsInputError> {
     let mut files = Vec::new();
     for entry in std::fs::read_dir(path).map_err(|err| GtfsInputError::Io {
@@ -1195,9 +1262,13 @@ fn collect_files(
             source: err,
         })?;
         let entry_path = entry.path();
-        if entry_path.is_dir() {
+        let file_type = entry.file_type().map_err(|err| GtfsInputError::Io {
+            path: entry_path.clone(),
+            source: err,
+        })?;
+        if file_type.is_dir() {
             collect_files(root, &entry_path, files)?;
-        } else if entry_path.is_file() {
+        } else if file_type.is_file() {
             let rel = entry_path
                 .strip_prefix(root)
                 .unwrap_or(&entry_path)
@@ -1300,19 +1371,21 @@ fn has_nested_gtfs_file_in_zip(path: &Path) -> Result<bool, GtfsInputError> {
 #[derive(Clone)]
 pub struct GtfsBytesReader {
     data: Vec<u8>,
+    remaining_bytes: Arc<AtomicU64>,
 }
 
 impl GtfsBytesReader {
     /// Create a new reader from ZIP file bytes
     pub fn from_zip_bytes(data: Vec<u8>) -> Self {
-        Self { data }
+        Self {
+            data,
+            remaining_bytes: Arc::new(AtomicU64::new(max_total_bytes())),
+        }
     }
 
     /// Create a new reader from a byte slice (copies the data)
     pub fn from_slice(data: &[u8]) -> Self {
-        Self {
-            data: data.to_vec(),
-        }
+        Self::from_zip_bytes(data.to_vec())
     }
 
     pub fn get_files_with_sizes(&self) -> Result<HashMap<String, u64>, GtfsInputError> {
@@ -1349,16 +1422,13 @@ impl GtfsBytesReader {
 
         // Try exact match first
         match archive.by_name(file_name) {
-            Ok(mut zipped) => {
-                let mut buffer = Vec::new();
-                zipped
-                    .read_to_end(&mut buffer)
-                    .map_err(|err| GtfsInputError::ZipFileIo {
-                        path: PathBuf::from("<memory>"),
-                        file: file_name.to_string(),
-                        source: err,
-                    })?;
-                return Ok(buffer);
+            Ok(zipped) => {
+                return read_zip_member_capped(
+                    zipped,
+                    Path::new("<memory>"),
+                    file_name,
+                    &self.remaining_bytes,
+                );
             }
             Err(zip::result::ZipError::FileNotFound) => {}
             Err(err) => {
@@ -1429,21 +1499,18 @@ impl GtfsBytesReader {
             return Err(GtfsInputError::MissingFile(file_name.to_string()));
         };
 
-        let mut zipped = archive
+        let zipped = archive
             .by_index(index)
             .map_err(|err| GtfsInputError::ZipFile {
                 file: file_name.to_string(),
                 source: err,
             })?;
-        let mut buffer = Vec::new();
-        zipped
-            .read_to_end(&mut buffer)
-            .map_err(|err| GtfsInputError::ZipFileIo {
-                path: PathBuf::from("<memory>"),
-                file: file_name.to_string(),
-                source: err,
-            })?;
-        Ok(buffer)
+        read_zip_member_capped(
+            zipped,
+            Path::new("<memory>"),
+            file_name,
+            &self.remaining_bytes,
+        )
     }
 
     #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
@@ -1469,6 +1536,15 @@ impl GtfsBytesReader {
                 file: file_name.to_string(),
                 source: err,
             })?;
+        let cap = max_member_bytes();
+        if zipped.size() > cap {
+            return Err(zip_member_too_large(
+                Path::new("<memory>"),
+                file_name,
+                zipped.size(),
+                cap,
+            ));
+        }
         if zipped.size() == 0 {
             notices.push_empty_table(file_name);
             return Ok(Some(CsvTable::default()));
@@ -1477,7 +1553,7 @@ impl GtfsBytesReader {
             .has_headers(true)
             .flexible(true)
             .trim(csv::Trim::Headers)
-            .from_reader(zipped);
+            .from_reader(zipped.take(65_536));
         let headers_record = header_reader
             .headers()
             .map_err(|err| {
@@ -1507,15 +1583,34 @@ impl GtfsBytesReader {
                 file: file_name.to_string(),
                 source: err,
             })?;
+        let capped = CappedReader::new(
+            zipped,
+            Path::new("<memory>"),
+            file_name,
+            cap,
+            &self.remaining_bytes,
+        );
         let (table, errors, row_notices) =
-            read_csv_from_reader_with_validation(zipped, file_name, |record, line| {
+            read_csv_from_reader_with_validation(capped, file_name, |record, line| {
                 if has_header_errors {
                     Vec::new()
                 } else {
                     validator.validate_row(record, line)
                 }
             })
-            .map_err(GtfsInputError::Csv)?;
+            .map_err(|err| {
+                if err.message.contains("per-file limit")
+                    || err.message.contains("total decompression limit")
+                {
+                    GtfsInputError::ZipFileIo {
+                        path: PathBuf::from("<memory>"),
+                        file: file_name.to_string(),
+                        source: std::io::Error::new(std::io::ErrorKind::InvalidData, err.message),
+                    }
+                } else {
+                    GtfsInputError::Csv(err)
+                }
+            })?;
 
         if !has_header_errors {
             for notice in row_notices {
@@ -1837,6 +1932,26 @@ mod tests {
         fs::remove_dir_all(&dir).ok();
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn directory_reader_rejects_symlinks() {
+        let dir = temp_path("gtfs_dir_symlink");
+        fs::create_dir_all(&dir).expect("create dir");
+        let target = dir.join("real.txt");
+        fs::write(&target, b"a,b\n1,2\n").expect("write target");
+        let link = dir.join("stops.txt");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+        let input = GtfsInput::from_path(&dir).expect("input");
+        let reader = input.reader();
+        let err = reader
+            .read_file("stops.txt")
+            .expect_err("symlink must fail");
+        assert!(matches!(err, GtfsInputError::NotAFile(_)));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
     #[test]
     fn reads_csv_from_zip() {
         let dir = temp_path("gtfs_zip");
@@ -1956,6 +2071,18 @@ mod tests {
             .expect_err("reading past the archive budget must error");
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
         assert!(err.to_string().contains("total decompression limit"));
+    }
+
+    #[test]
+    fn capped_reader_charges_budget_as_bytes_are_read() {
+        let data = vec![b'x'; 32];
+        let budget = AtomicU64::new(100);
+        let mut reader =
+            CappedReader::new(&data[..], Path::new("<test>"), "stops.txt", 100, &budget);
+        let mut buf = [0u8; 8];
+        let n = reader.read(&mut buf).expect("read");
+        assert_eq!(n, 8);
+        assert_eq!(budget.load(Ordering::Relaxed), 92);
     }
 
     #[test]

--- a/crates/gtfs_validator_core/src/input.rs
+++ b/crates/gtfs_validator_core/src/input.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{Cursor, Read, Seek};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 
 use serde::de::DeserializeOwned;
@@ -533,7 +533,7 @@ impl GtfsInputReader {
                 // bypass the zip-bomb guard.
                 let cap = max_member_bytes();
                 if zipped.size() > cap {
-                    return Err(zip_member_too_large(path, file_name, zipped.size(), cap));
+                    return Err(member_too_large(path, file_name, zipped.size(), cap));
                 }
                 if zipped.size() > remaining_bytes.load(Ordering::Relaxed) {
                     return Err(archive_budget_exceeded(path, file_name, max_total_bytes()));
@@ -541,7 +541,7 @@ impl GtfsInputReader {
                 let capped = CappedReader::new(zipped, path, file_name, cap, remaining_bytes);
                 let mut buf_reader = std::io::BufReader::with_capacity(1 << 20, capped);
                 skip_utf8_bom(&mut buf_reader).map_err(|err| {
-                    if is_limit_io_error(&err) {
+                    if limit_kind(&err).is_some() {
                         map_capped_read_error(path, file_name, cap, err)
                     } else {
                         GtfsInputError::Csv(map_io_error(file_name, err))
@@ -940,6 +940,12 @@ fn max_member_bytes() -> u64 {
         .unwrap_or(DEFAULT_MAX_MEMBER_BYTES)
 }
 
+/// How far the single-threaded reader will inflate a member looking for the end
+/// of its header row. Far above any real GTFS header, and bounded so a member
+/// that is one enormous line cannot be decompressed whole by the header pass.
+#[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
+const HEADER_SCAN_BYTES: u64 = 1 << 20;
+
 /// Upper bound on the *total* uncompressed size of a single archive, summed
 /// across every member read from it. This backstops [`max_member_bytes`]: even
 /// if every individual member stays under the per-member cap, an archive full of
@@ -954,14 +960,17 @@ fn max_total_bytes() -> u64 {
         .unwrap_or(DEFAULT_MAX_TOTAL_BYTES)
 }
 
-fn zip_member_too_large(path: &Path, file_name: &str, observed: u64, limit: u64) -> GtfsInputError {
+/// Used for both zip members and files read straight off disk, so the wording
+/// stays true either way: "uncompressed zip member" would be wrong for the
+/// directory reader, which shares this cap.
+fn member_too_large(path: &Path, file_name: &str, observed: u64, limit: u64) -> GtfsInputError {
     GtfsInputError::ZipFileIo {
         path: path.to_path_buf(),
         file: file_name.to_string(),
         source: std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!(
-                "zip member '{}' is {} bytes uncompressed, exceeding the {}-byte limit",
+                "'{}' is {} bytes, exceeding the {}-byte per-file limit",
                 file_name, observed, limit
             ),
         ),
@@ -1021,12 +1030,12 @@ fn read_zip_member_capped(
     let cap = max_member_bytes();
     let total_cap = max_total_bytes();
     if zipped.size() > cap {
-        return Err(zip_member_too_large(path, file_name, zipped.size(), cap));
+        return Err(member_too_large(path, file_name, zipped.size(), cap));
     }
     if zipped.size() > budget.load(Ordering::Relaxed) {
         return Err(archive_budget_exceeded(path, file_name, total_cap));
     }
-    read_capped_to_vec(zipped, path, file_name, cap, budget)
+    read_capped_to_vec(zipped, path, file_name, cap, budget, None)
 }
 
 fn read_filesystem_file_capped(
@@ -1043,7 +1052,7 @@ fn read_filesystem_file_capped(
         })?
         .len();
     if declared > cap {
-        return Err(zip_member_too_large(&path, file_name, declared, cap));
+        return Err(member_too_large(&path, file_name, declared, cap));
     }
     if declared > budget.load(Ordering::Relaxed) {
         return Err(archive_budget_exceeded(&path, file_name, total_cap));
@@ -1052,18 +1061,28 @@ fn read_filesystem_file_capped(
         path: path.clone(),
         source: err,
     })?;
-    read_capped_to_vec(file, &path, file_name, cap, budget)
+    read_capped_to_vec(file, &path, file_name, cap, budget, Some(declared))
 }
 
+/// `capacity_hint` is the size to preallocate, and must come from a source that
+/// cannot lie. `File::read_to_end` reserves from the real file size, and
+/// wrapping the file in [`CappedReader`] loses that, so the caller passes it
+/// back in. A zip member's declared size is written by whoever built the
+/// archive, so the zip path passes `None` rather than let a header reserve
+/// gigabytes it never fills.
 fn read_capped_to_vec<R: Read>(
     reader: R,
     path: &Path,
     file_name: &str,
     cap: u64,
     budget: &AtomicU64,
+    capacity_hint: Option<u64>,
 ) -> Result<Vec<u8>, GtfsInputError> {
     let mut capped = CappedReader::new(reader, path, file_name, cap, budget);
-    let mut buffer = Vec::new();
+    let mut buffer = match capacity_hint {
+        Some(size) => Vec::with_capacity(size.min(cap) as usize),
+        None => Vec::new(),
+    };
     capped
         .read_to_end(&mut buffer)
         .map_err(|err| map_capped_read_error(path, file_name, cap, err))?;
@@ -1076,34 +1095,89 @@ fn map_capped_read_error(
     cap: u64,
     err: std::io::Error,
 ) -> GtfsInputError {
-    if is_limit_io_error(&err) {
-        if err.to_string().contains("total decompression limit") {
-            archive_budget_exceeded(path, file_name, max_total_bytes())
-        } else {
-            zip_member_too_large(path, file_name, cap.saturating_add(1), cap)
+    match limit_kind(&err) {
+        Some(LimitKind::Total) => archive_budget_exceeded(path, file_name, max_total_bytes()),
+        Some(LimitKind::Member) => {
+            member_too_large(path, file_name, cap.saturating_add(1), cap)
         }
-    } else {
-        GtfsInputError::ZipFileIo {
-            path: path.to_path_buf(),
-            file: file_name.to_string(),
-            source: err,
+        None => {
+            GtfsInputError::ZipFileIo {
+                path: path.to_path_buf(),
+                file: file_name.to_string(),
+                source: err,
+            }
         }
     }
 }
 
-fn is_limit_io_error(err: &std::io::Error) -> bool {
-    err.kind() == std::io::ErrorKind::InvalidData
-        && (err.to_string().contains("per-file limit")
-            || err.to_string().contains("total decompression limit"))
+/// Which cap a [`CappedReader`] hit. Carried as the payload of the `io::Error`
+/// the reader yields so the error can be recognised by type rather than by the
+/// wording of a `format!`, which nothing would keep in sync.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LimitKind {
+    /// The per-member cap, [`max_member_bytes`].
+    Member,
+    /// The archive-wide budget, [`max_total_bytes`].
+    Total,
 }
 
+#[derive(Debug)]
+struct LimitExceeded {
+    kind: LimitKind,
+    file_name: String,
+    limit: u64,
+}
+
+impl std::fmt::Display for LimitExceeded {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            LimitKind::Member => write!(
+                f,
+                "zip member '{}' exceeds the {}-byte per-file limit",
+                self.file_name, self.limit
+            ),
+            LimitKind::Total => write!(
+                f,
+                "archive exceeds the {}-byte total decompression limit while reading '{}'",
+                self.limit, self.file_name
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LimitExceeded {}
+
+fn limit_io_error(kind: LimitKind, file_name: &str, limit: u64) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        LimitExceeded {
+            kind,
+            file_name: file_name.to_string(),
+            limit,
+        },
+    )
+}
+
+/// The cap an `io::Error` reports hitting, if it is one of ours.
+fn limit_kind(err: &std::io::Error) -> Option<LimitKind> {
+    err.get_ref()
+        .and_then(|inner| inner.downcast_ref::<LimitExceeded>())
+        .map(|exceeded| exceeded.kind)
+}
+
+/// Re-wrap the limit error a CSV reader swallowed, preserving the sentinel so
+/// the caller still recognises it by type.
+#[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
 fn csv_limit_io_error(err: &csv::Error) -> Option<std::io::Error> {
-    match err.kind() {
-        csv::ErrorKind::Io(io_err) if is_limit_io_error(io_err) => {
-            Some(std::io::Error::new(io_err.kind(), io_err.to_string()))
-        }
-        _ => None,
-    }
+    let csv::ErrorKind::Io(io_err) = err.kind() else {
+        return None;
+    };
+    let exceeded = io_err.get_ref()?.downcast_ref::<LimitExceeded>()?;
+    Some(limit_io_error(
+        exceeded.kind,
+        &exceeded.file_name,
+        exceeded.limit,
+    ))
 }
 
 /// A `Read` adapter that enforces the per-member and archive-wide decompression
@@ -1119,7 +1193,15 @@ struct CappedReader<'a, R> {
     member_cap: u64,
     total_cap: u64,
     budget: &'a AtomicU64,
+    /// Set when a cap is hit. A reader handed to a CSV parser is moved out of
+    /// reach, and the parser flattens the `io::Error` into a string, so this is
+    /// how the caller recovers the reason by value rather than by substring.
+    limit_hit: Arc<AtomicU8>,
 }
+
+const LIMIT_HIT_NONE: u8 = 0;
+const LIMIT_HIT_MEMBER: u8 = 1;
+const LIMIT_HIT_TOTAL: u8 = 2;
 
 impl<'a, R> CappedReader<'a, R> {
     fn new(
@@ -1136,7 +1218,27 @@ impl<'a, R> CappedReader<'a, R> {
             member_cap,
             total_cap: max_total_bytes(),
             budget,
+            limit_hit: Arc::new(AtomicU8::new(LIMIT_HIT_NONE)),
         }
+    }
+
+    /// A handle to this reader's limit flag, to keep after the reader is moved
+    /// into a parser. Only the single-threaded reader needs it: the parallel
+    /// path keeps the `io::Error` and reads the sentinel off it directly.
+    #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
+    fn limit_flag(&self) -> Arc<AtomicU8> {
+        self.limit_hit.clone()
+    }
+}
+
+/// The cap a [`CappedReader`] hit, read back through a flag from
+/// [`CappedReader::limit_flag`].
+#[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
+fn limit_kind_from_flag(flag: &AtomicU8) -> Option<LimitKind> {
+    match flag.load(Ordering::Relaxed) {
+        LIMIT_HIT_MEMBER => Some(LimitKind::Member),
+        LIMIT_HIT_TOTAL => Some(LimitKind::Total),
+        _ => None,
     }
 }
 
@@ -1157,22 +1259,20 @@ impl<R: Read> Read for CappedReader<'_, R> {
         }
         let n64 = n as u64;
         if n64 > self.member_remaining {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "zip member '{}' exceeds the {}-byte per-file limit",
-                    self.file_name, self.member_cap
-                ),
+            self.limit_hit.store(LIMIT_HIT_MEMBER, Ordering::Relaxed);
+            return Err(limit_io_error(
+                LimitKind::Member,
+                &self.file_name,
+                self.member_cap,
             ));
         }
         self.member_remaining -= n64;
         if charge_archive_budget(self.budget, n64).is_err() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "archive exceeds the {}-byte total decompression limit while reading '{}'",
-                    self.total_cap, self.file_name
-                ),
+            self.limit_hit.store(LIMIT_HIT_TOTAL, Ordering::Relaxed);
+            return Err(limit_io_error(
+                LimitKind::Total,
+                &self.file_name,
+                self.total_cap,
             ));
         }
         Ok(n)
@@ -1538,7 +1638,7 @@ impl GtfsBytesReader {
             })?;
         let cap = max_member_bytes();
         if zipped.size() > cap {
-            return Err(zip_member_too_large(
+            return Err(member_too_large(
                 Path::new("<memory>"),
                 file_name,
                 zipped.size(),
@@ -1553,13 +1653,31 @@ impl GtfsBytesReader {
             .has_headers(true)
             .flexible(true)
             .trim(csv::Trim::Headers)
-            .from_reader(zipped.take(65_536));
+            .from_reader(zipped.take(HEADER_SCAN_BYTES + 1));
         let headers_record = header_reader
             .headers()
             .map_err(|err| {
                 GtfsInputError::Csv(crate::csv_reader::map_csv_error(file_name, None, err))
             })?
             .clone();
+        // The header pass is bounded so a member with no line break cannot be
+        // inflated whole just to find the columns. Hitting that bound means the
+        // record was cut mid-field, and the second pass would then read a longer
+        // header than the `RowValidator` was built from -- so refuse instead of
+        // validating against a header we know is wrong.
+        if header_reader.into_inner().limit() == 0 {
+            return Err(GtfsInputError::ZipFileIo {
+                path: PathBuf::from("<memory>"),
+                file: file_name.to_string(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "'{}' has no complete header row in its first {} bytes",
+                        file_name, HEADER_SCAN_BYTES
+                    ),
+                ),
+            });
+        }
         let headers: Vec<String> = headers_record.iter().map(str::to_string).collect();
 
         let mut header_notices = NoticeContainer::new();
@@ -1569,7 +1687,6 @@ impl GtfsBytesReader {
             .any(|notice| notice.severity == NoticeSeverity::Error);
         notices.merge(header_notices);
         let validator = RowValidator::new(file_name, headers);
-        drop(header_reader);
         drop(archive);
 
         let cursor = Cursor::new(&self.data);
@@ -1590,6 +1707,9 @@ impl GtfsBytesReader {
             cap,
             &self.remaining_bytes,
         );
+        // The parser flattens our `io::Error` into a message string, so the
+        // reason is read back off the reader's own flag instead.
+        let limit_flag = capped.limit_flag();
         let (table, errors, row_notices) =
             read_csv_from_reader_with_validation(capped, file_name, |record, line| {
                 if has_header_errors {
@@ -1598,18 +1718,19 @@ impl GtfsBytesReader {
                     validator.validate_row(record, line)
                 }
             })
-            .map_err(|err| {
-                if err.message.contains("per-file limit")
-                    || err.message.contains("total decompression limit")
-                {
+            .map_err(|err| match limit_kind_from_flag(&limit_flag) {
+                Some(kind) => {
+                    let limit = match kind {
+                        LimitKind::Member => cap,
+                        LimitKind::Total => max_total_bytes(),
+                    };
                     GtfsInputError::ZipFileIo {
                         path: PathBuf::from("<memory>"),
                         file: file_name.to_string(),
-                        source: std::io::Error::new(std::io::ErrorKind::InvalidData, err.message),
+                        source: limit_io_error(kind, file_name, limit),
                     }
-                } else {
-                    GtfsInputError::Csv(err)
                 }
+                None => GtfsInputError::Csv(err),
             })?;
 
         if !has_header_errors {
@@ -2071,6 +2192,67 @@ mod tests {
             .expect_err("reading past the archive budget must error");
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
         assert!(err.to_string().contains("total decompression limit"));
+    }
+
+    #[test]
+    fn limit_errors_carry_their_kind_through_a_csv_error() {
+        let member = limit_io_error(LimitKind::Member, "stops.txt", 16);
+        assert_eq!(limit_kind(&member), Some(LimitKind::Member));
+        assert!(member.to_string().contains("per-file limit"));
+
+        let total = limit_io_error(LimitKind::Total, "stops.txt", 16);
+        assert_eq!(limit_kind(&total), Some(LimitKind::Total));
+        assert!(total.to_string().contains("total decompression limit"));
+
+        // A plain io error must not be mistaken for one of ours, however it
+        // happens to be worded.
+        let impostor = std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "cell text mentioning a per-file limit and a total decompression limit",
+        );
+        assert_eq!(limit_kind(&impostor), None);
+    }
+
+    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    #[test]
+    fn csv_limit_io_error_preserves_the_sentinel() {
+        let wrapped = csv::Error::from(limit_io_error(LimitKind::Total, "stops.txt", 32));
+        let recovered = csv_limit_io_error(&wrapped).expect("limit error must survive the csv wrap");
+        assert_eq!(limit_kind(&recovered), Some(LimitKind::Total));
+
+        let unrelated = csv::Error::from(std::io::Error::other("disk gone"));
+        assert!(csv_limit_io_error(&unrelated).is_none());
+    }
+
+    #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
+    #[test]
+    fn header_pass_refuses_a_member_with_no_header_row_in_range() {
+        use std::io::Write as _;
+
+        let mut buffer = Vec::new();
+        {
+            let mut zip = ZipWriter::new(Cursor::new(&mut buffer));
+            zip.start_file("stops.txt", FileOptions::default())
+                .expect("zip file");
+            // One unterminated line, longer than the header scan window.
+            zip.write_all(&vec![b'a'; (HEADER_SCAN_BYTES + 2048) as usize])
+                .expect("zip data");
+            zip.finish().expect("finish zip");
+        }
+
+        let reader = GtfsBytesReader::from_zip_bytes(buffer);
+        let mut notices = NoticeContainer::new();
+        let err = reader
+            .read_optional_csv_with_notices::<ExampleRow>(
+                "stops.txt",
+                &mut notices,
+                &crate::StringPool::new(),
+            )
+            .expect_err("a header row that never ends must be refused");
+        assert!(
+            err.to_string().contains("no complete header row"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/gtfs_validator_core/src/rules/block_trips_with_overlapping_stop_times.rs
+++ b/crates/gtfs_validator_core/src/rules/block_trips_with_overlapping_stop_times.rs
@@ -60,11 +60,17 @@ impl Validator for BlockTripsWithOverlappingStopTimesValidator {
             });
         }
 
-        for windows in blocks.values_mut() {
+        let mut groups: Vec<_> = blocks.into_iter().collect();
+        groups.sort_by(|(left_id, _), (right_id, _)| {
+            feed.pool
+                .resolve(*left_id)
+                .cmp(&feed.pool.resolve(*right_id))
+        });
+        for (_, windows) in &mut groups {
             windows.sort_by_key(|window| window.start.total_seconds());
         }
 
-        for windows in blocks.values() {
+        for (_, windows) in &groups {
             for i in 0..windows.len() {
                 let current = &windows[i];
                 for next in windows.iter().skip(i + 1) {

--- a/crates/gtfs_validator_core/src/rules/google_rules.rs
+++ b/crates/gtfs_validator_core/src/rules/google_rules.rs
@@ -397,7 +397,25 @@ impl Validator for DuplicateTripValidator {
                 .push(trip_id);
         }
 
-        for (_signature, trip_ids) in trips_by_signature {
+        let mut groups: Vec<_> = trips_by_signature.into_iter().collect();
+        for (_, trip_ids) in &mut groups {
+            trip_ids.sort_by_cached_key(|id| feed.pool.resolve(*id));
+        }
+        groups.sort_by(|left, right| {
+            let left_name = left
+                .1
+                .first()
+                .map(|id| feed.pool.resolve(*id))
+                .unwrap_or_default();
+            let right_name = right
+                .1
+                .first()
+                .map(|id| feed.pool.resolve(*id))
+                .unwrap_or_default();
+            left_name.cmp(&right_name)
+        });
+
+        for (_signature, trip_ids) in groups {
             if trip_ids.len() > 1 {
                 let mut notice = ValidationNotice::new(
                     "duplicate_trip",

--- a/crates/gtfs_validator_core/src/rules/shapes.rs
+++ b/crates/gtfs_validator_core/src/rules/shapes.rs
@@ -38,7 +38,20 @@ impl Validator for ShapeIncreasingDistanceValidator {
                 shape_points.sort_by_key(|(_, shape)| shape.shape_pt_sequence);
             }
 
-            for shape_points in by_shape.values() {
+            let mut groups: Vec<_> = by_shape.into_iter().collect();
+            groups.sort_by(|(left_id, left_points), (right_id, right_points)| {
+                feed.pool
+                    .resolve(*left_id)
+                    .cmp(&feed.pool.resolve(*right_id))
+                    .then_with(|| {
+                        left_points
+                            .first()
+                            .map(|(row, _)| *row)
+                            .cmp(&right_points.first().map(|(row, _)| *row))
+                    })
+            });
+
+            for (_, shape_points) in groups {
                 for window in shape_points.windows(2) {
                     let (prev_row, prev) = window[0];
                     let (curr_row, curr) = window[1];

--- a/crates/gtfs_validator_core/src/rules/v8_data_quality.rs
+++ b/crates/gtfs_validator_core/src/rules/v8_data_quality.rs
@@ -99,7 +99,12 @@ impl Validator for UnsortedStopTimesValidator {
         for (index, stop_time) in feed.stop_times.rows.iter().enumerate() {
             if stop_time.trip_id.0 == 0 {
                 if current_trip.0 != 0 {
-                    merge_group(&mut stats_by_trip, &mut trip_order, current_trip, current_stats);
+                    merge_group(
+                        &mut stats_by_trip,
+                        &mut trip_order,
+                        current_trip,
+                        current_stats,
+                    );
                     current_trip = StringId(0);
                     current_stats = Stats::default();
                 }
@@ -107,7 +112,12 @@ impl Validator for UnsortedStopTimesValidator {
             }
             if stop_time.trip_id != current_trip {
                 if current_trip.0 != 0 {
-                    merge_group(&mut stats_by_trip, &mut trip_order, current_trip, current_stats);
+                    merge_group(
+                        &mut stats_by_trip,
+                        &mut trip_order,
+                        current_trip,
+                        current_stats,
+                    );
                 }
                 current_trip = stop_time.trip_id;
                 current_stats = Stats::default();
@@ -130,7 +140,12 @@ impl Validator for UnsortedStopTimesValidator {
             current_stats.last_sequence = Some(stop_time.stop_sequence);
         }
         if current_trip.0 != 0 {
-            merge_group(&mut stats_by_trip, &mut trip_order, current_trip, current_stats);
+            merge_group(
+                &mut stats_by_trip,
+                &mut trip_order,
+                current_trip,
+                current_stats,
+            );
         }
         for trip_id in trip_order {
             let stats = &stats_by_trip[&trip_id];

--- a/crates/gtfs_validator_mcp/src/lib.rs
+++ b/crates/gtfs_validator_mcp/src/lib.rs
@@ -49,7 +49,7 @@ const GTFS_MARKER_FILES: [&str; 2] = ["agency.txt", "stops.txt"];
 fn is_gtfs_directory(path: &Path) -> bool {
     GTFS_MARKER_FILES
         .iter()
-        .any(|marker| path.join(marker).is_file())
+        .all(|marker| path.join(marker).is_file())
 }
 
 #[derive(Debug, Clone)]
@@ -1006,6 +1006,7 @@ mod tests {
         let unzipped = root.join("berlin_unzipped");
         fs::create_dir_all(&unzipped).unwrap();
         fs::write(unzipped.join("agency.txt"), b"agency_id\n").unwrap();
+        fs::write(unzipped.join("stops.txt"), b"stop_id\n").unwrap();
 
         let service = GtfsGuruMcp::new(McpConfig::local(vec![root.clone()]).unwrap());
 
@@ -1023,6 +1024,22 @@ mod tests {
         assert_eq!(service.scan_feeds(Some("   ")).feed_count, 4);
         assert_eq!(service.scan_feeds(None).feed_count, 4);
         assert_eq!(service.scan_feeds(Some("nothing-matches")).feed_count, 0);
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn unzipped_feed_requires_both_marker_files() {
+        let root = temp_dir("markers");
+        let unzipped = root.join("partial");
+        fs::create_dir_all(&unzipped).unwrap();
+        fs::write(unzipped.join("agency.txt"), b"agency_id\n").unwrap();
+
+        let service = GtfsGuruMcp::new(McpConfig::local(vec![root.clone()]).unwrap());
+        assert_eq!(service.scan_feeds(None).feed_count, 0);
+
+        fs::write(unzipped.join("stops.txt"), b"stop_id\n").unwrap();
+        assert_eq!(service.scan_feeds(None).feed_count, 1);
 
         fs::remove_dir_all(root).ok();
     }

--- a/crates/gtfs_validator_web/Cargo.toml
+++ b/crates/gtfs_validator_web/Cargo.toml
@@ -13,10 +13,11 @@ publish = false
 anyhow = { workspace = true }
 axum = { workspace = true }
 base64 = { workspace = true }
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "io-util"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }

--- a/crates/gtfs_validator_web/src/main.rs
+++ b/crates/gtfs_validator_web/src/main.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use anyhow::{bail, Context};
 use axum::{
     body::Body,
-    extract::{DefaultBodyLimit, Path as AxumPath, Query, State},
+    extract::{DefaultBodyLimit, Path as AxumPath, Query, Request, State},
     http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, post, put},
@@ -16,14 +16,15 @@ use axum::{
 };
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
+use futures_util::StreamExt;
+use include_dir::{include_dir, Dir};
+use mime_guess::MimeGuess;
 use reqwest::blocking::Client;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 use tokio::sync::Semaphore;
-
-use include_dir::{include_dir, Dir};
-use mime_guess::MimeGuess;
 
 use gtfs_guru_core::{default_runner, validate_input, GtfsInput, NoticeContainer};
 use gtfs_guru_report::{
@@ -49,6 +50,19 @@ const DEFAULT_MAX_CONCURRENT_JOBS: usize = 4;
 /// control). Overridable via `GTFS_VALIDATOR_WEB_MAX_QUEUED_JOBS`. Without this,
 /// a flood of requests would spawn unbounded tasks all waiting for a run permit.
 const DEFAULT_MAX_QUEUED_JOBS: usize = 64;
+
+/// Concurrent upload streams that may write to disk at once. Overridable via
+/// `GTFS_VALIDATOR_WEB_MAX_CONCURRENT_UPLOADS`. Distinct from validation
+/// concurrency: this bounds how many request bodies we will accept, not how
+/// many feeds we will parse.
+const DEFAULT_MAX_CONCURRENT_UPLOADS: usize = 4;
+
+/// How long a job may stay in `Processing` before cleanup reclaims it.
+/// Overridable via `GTFS_VALIDATOR_WEB_PROCESSING_TIMEOUT_SECONDS`.
+const DEFAULT_PROCESSING_TIMEOUT_SECS: u128 = 30 * 60;
+
+/// Global create-job requests accepted per minute.
+const DEFAULT_MAX_CREATE_JOB_REQUESTS_PER_MINUTE: usize = 60;
 
 /// Keep the browser proxy aligned with the WASM validator's input limit.
 const DEFAULT_MAX_PROXY_BYTES: usize = 70 * 1024 * 1024;
@@ -164,28 +178,41 @@ struct AppState {
     base_dir: PathBuf,
     public_base_url: String,
     max_upload_bytes: usize,
+    max_queued_jobs: usize,
     job_semaphore: Arc<Semaphore>,
     admission_semaphore: Arc<Semaphore>,
+    upload_semaphore: Arc<Semaphore>,
     max_proxy_bytes: usize,
     proxy_semaphore: Arc<Semaphore>,
     proxy_rate_limiter: Arc<ProxyRateLimiter>,
+    job_create_rate_limiter: Arc<ProxyRateLimiter>,
+    pubsub_token: Option<String>,
+    processing_timeout_ms: u128,
 }
 
 impl AppState {
     fn new(base_dir: PathBuf, public_base_url: String) -> Self {
         let jobs = load_jobs(&base_dir);
+        let max_queued_jobs = load_max_queued_jobs();
         Self {
             jobs: Arc::new(RwLock::new(jobs)),
             base_dir,
             public_base_url,
             max_upload_bytes: load_max_upload_bytes(),
+            max_queued_jobs,
             job_semaphore: Arc::new(Semaphore::new(load_max_concurrent_jobs())),
-            admission_semaphore: Arc::new(Semaphore::new(load_max_queued_jobs())),
+            admission_semaphore: Arc::new(Semaphore::new(max_queued_jobs)),
+            upload_semaphore: Arc::new(Semaphore::new(load_max_concurrent_uploads())),
             max_proxy_bytes: load_max_proxy_bytes(),
             proxy_semaphore: Arc::new(Semaphore::new(load_max_concurrent_proxy_requests())),
             proxy_rate_limiter: Arc::new(ProxyRateLimiter::new(
                 load_max_proxy_requests_per_minute(),
             )),
+            job_create_rate_limiter: Arc::new(ProxyRateLimiter::new(
+                load_max_create_job_requests_per_minute(),
+            )),
+            pubsub_token: load_pubsub_token(),
+            processing_timeout_ms: load_processing_timeout_ms(),
         }
     }
 }
@@ -212,6 +239,41 @@ fn load_max_queued_jobs() -> usize {
         .and_then(|value| value.trim().parse::<usize>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(DEFAULT_MAX_QUEUED_JOBS)
+}
+
+fn load_max_concurrent_uploads() -> usize {
+    load_positive_usize(
+        "GTFS_VALIDATOR_WEB_MAX_CONCURRENT_UPLOADS",
+        DEFAULT_MAX_CONCURRENT_UPLOADS,
+    )
+}
+
+fn load_max_create_job_requests_per_minute() -> usize {
+    load_positive_usize(
+        "GTFS_VALIDATOR_WEB_MAX_CREATE_JOB_REQUESTS_PER_MINUTE",
+        DEFAULT_MAX_CREATE_JOB_REQUESTS_PER_MINUTE,
+    )
+}
+
+fn load_pubsub_token() -> Option<String> {
+    std::env::var("GTFS_VALIDATOR_WEB_PUBSUB_TOKEN")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn load_processing_timeout_ms() -> u128 {
+    let default_ms = DEFAULT_PROCESSING_TIMEOUT_SECS.saturating_mul(1000);
+    match std::env::var("GTFS_VALIDATOR_WEB_PROCESSING_TIMEOUT_SECONDS") {
+        Ok(value) => value
+            .trim()
+            .parse::<u128>()
+            .ok()
+            .filter(|seconds| *seconds > 0)
+            .map(|seconds| seconds.saturating_mul(1000))
+            .unwrap_or(default_ms),
+        Err(_) => default_ms,
+    }
 }
 
 fn load_max_proxy_bytes() -> usize {
@@ -450,7 +512,17 @@ fn plain_text_response(status: StatusCode, message: &'static str) -> Response {
 async fn create_job(
     State(state): State<AppState>,
     body: Option<Json<CreateJobRequest>>,
-) -> Json<CreateJobResponse> {
+) -> Response {
+    if !state.job_create_rate_limiter.try_acquire(Instant::now()) {
+        return plain_text_response(
+            StatusCode::TOO_MANY_REQUESTS,
+            "job creation rate limit exceeded",
+        );
+    }
+    if awaiting_upload_count(&state) >= state.max_queued_jobs {
+        return plain_text_response(StatusCode::TOO_MANY_REQUESTS, "too many pending uploads");
+    }
+
     let job_id = next_job_id();
     let job_dir = state.base_dir.join(&job_id);
     let _ = tokio::fs::create_dir_all(&job_dir).await;
@@ -477,19 +549,24 @@ async fn create_job(
 
     if let Some(url) = source_url {
         spawn_job_processing(state.clone(), job_id.clone(), url);
-        Json(CreateJobResponse { job_id, url: None })
+        Json(CreateJobResponse { job_id, url: None }).into_response()
     } else {
         Json(CreateJobResponse {
             job_id: job_id.clone(),
             url: Some(format!("{}/upload/{}", state.public_base_url, job_id)),
         })
+        .into_response()
     }
 }
 
 async fn run_validator(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<PubsubEnvelope>,
 ) -> StatusCode {
+    if !pubsub_token_matches(&state, &headers) {
+        return StatusCode::UNAUTHORIZED;
+    }
     let data = payload
         .message
         .and_then(|msg| msg.data)
@@ -516,17 +593,44 @@ async fn error() -> StatusCode {
 async fn upload_job(
     State(state): State<AppState>,
     AxumPath(job_id): AxumPath<String>,
-    body: axum::body::Bytes,
+    request: Request,
 ) -> StatusCode {
-    // Claim the job before touching input.zip so a redelivered upload or a
-    // concurrent run cannot overwrite the input of an already-running job.
+    // Claim the job before touching the body so a missing or already-running
+    // id does not force the process to buffer hundreds of megabytes first.
     match try_begin_processing(&state, &job_id) {
         BeginOutcome::NotFound => return StatusCode::NOT_FOUND,
         BeginOutcome::AlreadyActive => return StatusCode::CONFLICT,
         BeginOutcome::Started => {}
     }
+    let admission = match state.admission_semaphore.clone().try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(_) => {
+            update_job_status(
+                &state,
+                &job_id,
+                JobStatus::Error,
+                Some("server is at capacity; please retry later".to_string()),
+            );
+            return StatusCode::TOO_MANY_REQUESTS;
+        }
+    };
+    let upload_permit = match state.upload_semaphore.clone().try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(_) => {
+            drop(admission);
+            update_job_status(
+                &state,
+                &job_id,
+                JobStatus::Error,
+                Some("server is at capacity; please retry later".to_string()),
+            );
+            return StatusCode::TOO_MANY_REQUESTS;
+        }
+    };
     let job_dir = state.base_dir.join(&job_id);
     if tokio::fs::create_dir_all(&job_dir).await.is_err() {
+        drop(upload_permit);
+        drop(admission);
         update_job_status(
             &state,
             &job_id,
@@ -536,17 +640,35 @@ async fn upload_job(
         return StatusCode::INTERNAL_SERVER_ERROR;
     }
     let input_path = job_dir.join("input.zip");
-    if tokio::fs::write(&input_path, body).await.is_err() {
-        update_job_status(
-            &state,
-            &job_id,
-            JobStatus::Error,
-            Some("failed to persist upload".to_string()),
-        );
-        return StatusCode::INTERNAL_SERVER_ERROR;
+    let max_upload_bytes = state.max_upload_bytes;
+    match stream_body_to_file(request.into_body(), &input_path, max_upload_bytes).await {
+        Ok(()) => {}
+        Err(StreamBodyError::TooLarge) => {
+            drop(upload_permit);
+            drop(admission);
+            update_job_status(
+                &state,
+                &job_id,
+                JobStatus::Error,
+                Some("upload exceeds the configured size limit".to_string()),
+            );
+            return StatusCode::PAYLOAD_TOO_LARGE;
+        }
+        Err(StreamBodyError::Io) => {
+            drop(upload_permit);
+            drop(admission);
+            update_job_status(
+                &state,
+                &job_id,
+                JobStatus::Error,
+                Some("failed to persist upload".to_string()),
+            );
+            return StatusCode::INTERNAL_SERVER_ERROR;
+        }
     }
+    drop(upload_permit);
     update_job_input(&state, &job_id, input_path);
-    spawn_job_processing(state, job_id, String::new());
+    spawn_job_processing_admitted(state, job_id, String::new(), admission);
     StatusCode::OK
 }
 
@@ -702,6 +824,15 @@ fn spawn_job_processing(state: AppState, job_id: String, url: String) {
             return;
         }
     };
+    spawn_job_processing_admitted(state, job_id, url, admission);
+}
+
+fn spawn_job_processing_admitted(
+    state: AppState,
+    job_id: String,
+    url: String,
+    admission: tokio::sync::OwnedSemaphorePermit,
+) {
     tokio::spawn(async move {
         // Held for the whole lifetime of the job so the admission count only
         // drops once this job is fully done.
@@ -711,7 +842,15 @@ fn spawn_job_processing(state: AppState, job_id: String, url: String) {
         // download + validation and released when the blocking task returns.
         let permit = match state.job_semaphore.clone().acquire_owned().await {
             Ok(permit) => permit,
-            Err(_) => return, // semaphore closed => shutting down
+            Err(_) => {
+                update_job_status(
+                    &state,
+                    &job_id,
+                    JobStatus::Error,
+                    Some("server is shutting down".to_string()),
+                );
+                return;
+            }
         };
         let state_for_block = state.clone();
         let job_id_for_block = job_id.clone();
@@ -731,6 +870,78 @@ fn spawn_job_processing(state: AppState, job_id: String, url: String) {
             );
         }
     });
+}
+
+enum StreamBodyError {
+    TooLarge,
+    Io,
+}
+
+async fn stream_body_to_file(
+    body: Body,
+    path: &Path,
+    max_bytes: usize,
+) -> Result<(), StreamBodyError> {
+    let mut file = tokio::fs::File::create(path)
+        .await
+        .map_err(|_| StreamBodyError::Io)?;
+    let mut written = 0usize;
+    let mut stream = body.into_data_stream();
+    while let Some(chunk) = stream.next().await {
+        let data = chunk.map_err(|_| StreamBodyError::Io)?;
+        if written.saturating_add(data.len()) > max_bytes {
+            drop(file);
+            let _ = tokio::fs::remove_file(path).await;
+            return Err(StreamBodyError::TooLarge);
+        }
+        written += data.len();
+        if file.write_all(&data).await.is_err() {
+            drop(file);
+            let _ = tokio::fs::remove_file(path).await;
+            return Err(StreamBodyError::Io);
+        }
+    }
+    if file.flush().await.is_err() {
+        let _ = tokio::fs::remove_file(path).await;
+        return Err(StreamBodyError::Io);
+    }
+    Ok(())
+}
+
+fn awaiting_upload_count(state: &AppState) -> usize {
+    state
+        .jobs
+        .read()
+        .ok()
+        .map(|jobs| {
+            jobs.values()
+                .filter(|job| matches!(job.status, JobStatus::AwaitingUpload))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+fn pubsub_token_matches(state: &AppState, headers: &HeaderMap) -> bool {
+    let Some(expected) = state.pubsub_token.as_deref() else {
+        return false;
+    };
+    extract_pubsub_token(headers).is_some_and(|value| value == expected)
+}
+
+fn extract_pubsub_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get("x-pubsub-token")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            headers
+                .get(header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.strip_prefix("Bearer "))
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        })
 }
 
 /// Result of trying to move a job into the `Processing` state.
@@ -1165,9 +1376,6 @@ fn cleanup_jobs(state: &AppState, ttl_ms: u128) {
     if let Ok(jobs) = state.jobs.read() {
         for (job_id, job) in jobs.iter() {
             known_ids.insert(job_id.clone());
-            if matches!(job.status, JobStatus::Processing) {
-                continue;
-            }
             let job_dir = state.base_dir.join(job_id);
             // Prefer metadata timestamp; fall back to the directory mtime, then
             // to 0 (== expired) so a job whose metadata is unreadable is still
@@ -1175,7 +1383,13 @@ fn cleanup_jobs(state: &AppState, ttl_ms: u128) {
             let updated_at = read_metadata_timestamp(&job_dir.join("job.json"))
                 .or_else(|| dir_mtime_millis(&job_dir))
                 .unwrap_or(0);
-            if now.saturating_sub(updated_at) >= ttl_ms {
+            let age = now.saturating_sub(updated_at);
+            let timed_out_processing =
+                matches!(job.status, JobStatus::Processing) && age >= state.processing_timeout_ms;
+            if matches!(job.status, JobStatus::Processing) && !timed_out_processing {
+                continue;
+            }
+            if timed_out_processing || age >= ttl_ms {
                 expired.push((job_id.clone(), job.output_dir.clone()));
             }
         }
@@ -1519,5 +1733,34 @@ mod tests {
             response.headers().get(header::CONTENT_TYPE),
             Some(&header::HeaderValue::from_static("text/html"))
         );
+    }
+
+    #[test]
+    fn pubsub_token_is_read_from_custom_header_or_bearer() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-pubsub-token", header::HeaderValue::from_static("abc"));
+        assert_eq!(extract_pubsub_token(&headers), Some("abc"));
+
+        headers.remove("x-pubsub-token");
+        headers.insert(
+            header::AUTHORIZATION,
+            header::HeaderValue::from_static("Bearer secret"),
+        );
+        assert_eq!(extract_pubsub_token(&headers), Some("secret"));
+
+        headers.insert(
+            header::AUTHORIZATION,
+            header::HeaderValue::from_static("Basic nope"),
+        );
+        assert_eq!(extract_pubsub_token(&headers), None);
+    }
+
+    #[test]
+    fn stream_size_check_rejects_a_chunk_past_the_cap() {
+        let written = 4usize;
+        let incoming = 2usize;
+        let max_bytes = 5usize;
+        assert!(written.saturating_add(incoming) > max_bytes);
+        assert!(written.saturating_add(1) <= max_bytes);
     }
 }

--- a/crates/gtfs_validator_web/src/main.rs
+++ b/crates/gtfs_validator_web/src/main.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use anyhow::{bail, Context};
 use axum::{
     body::Body,
-    extract::{DefaultBodyLimit, Path as AxumPath, Query, Request, State},
+    extract::{Path as AxumPath, Query, Request, State},
     http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, post, put},
@@ -79,7 +79,6 @@ async fn main() -> anyhow::Result<()> {
     let state = AppState::new(base_dir, public_base_url);
     spawn_job_cleanup(state.clone());
 
-    let max_upload_bytes = state.max_upload_bytes;
     let app = Router::new()
         .route("/healthz", get(|| async { "ok" }))
         .route("/version", get(version))
@@ -87,10 +86,11 @@ async fn main() -> anyhow::Result<()> {
         .route("/create-job", post(create_job))
         .route("/run-validator", post(run_validator))
         .route("/error", post(error))
-        .route(
-            "/upload/:job_id",
-            put(upload_job).layer(DefaultBodyLimit::max(max_upload_bytes)),
-        )
+        // No `DefaultBodyLimit` here: it is honoured only by extractors that
+        // call `into_limited_body` (`Bytes`, `Json`, `Form`), and `upload_job`
+        // takes the raw `Request` so it can stream to disk. The cap is enforced
+        // by the Content-Length pre-check and by `stream_body_to_file`.
+        .route("/upload/:job_id", put(upload_job))
         .route("/jobs/:job_id/status", get(job_status))
         .route("/jobs/:job_id/report.json", get(job_report_json))
         .route("/jobs/:job_id/report.html", get(job_report_html))
@@ -519,10 +519,6 @@ async fn create_job(
             "job creation rate limit exceeded",
         );
     }
-    if awaiting_upload_count(&state) >= state.max_queued_jobs {
-        return plain_text_response(StatusCode::TOO_MANY_REQUESTS, "too many pending uploads");
-    }
-
     let job_id = next_job_id();
     let job_dir = state.base_dir.join(&job_id);
     let _ = tokio::fs::create_dir_all(&job_dir).await;
@@ -545,7 +541,12 @@ async fn create_job(
         output_dir: Some(job_dir.join("output")),
         error: None,
     };
-    insert_job(&state, job);
+    // Counting and inserting under one write lock: two concurrent creates
+    // cannot both observe the last free slot and both take it.
+    if !insert_job_within_pending_cap(&state, job) {
+        let _ = tokio::fs::remove_dir_all(&job_dir).await;
+        return plain_text_response(StatusCode::TOO_MANY_REQUESTS, "too many pending uploads");
+    }
 
     if let Some(url) = source_url {
         spawn_job_processing(state.clone(), job_id.clone(), url);
@@ -595,6 +596,11 @@ async fn upload_job(
     AxumPath(job_id): AxumPath<String>,
     request: Request,
 ) -> StatusCode {
+    // A declared length over the cap is refused before the job is claimed, so a
+    // client that announces an oversized body neither burns an id nor uploads.
+    if declared_length_over_cap(request.headers(), state.max_upload_bytes) {
+        return StatusCode::PAYLOAD_TOO_LARGE;
+    }
     // Claim the job before touching the body so a missing or already-running
     // id does not force the process to buffer hundreds of megabytes first.
     match try_begin_processing(&state, &job_id) {
@@ -754,14 +760,6 @@ fn load_public_base_url() -> String {
     }
 }
 
-fn insert_job(state: &AppState, job: Job) {
-    let job_id = job.id.clone();
-    if let Ok(mut jobs) = state.jobs.write() {
-        jobs.insert(job_id.clone(), job);
-    }
-    persist_job_metadata(state, job_id.as_str());
-}
-
 fn get_job(state: &AppState, job_id: &str) -> Option<Job> {
     state
         .jobs
@@ -908,24 +906,66 @@ async fn stream_body_to_file(
     Ok(())
 }
 
-fn awaiting_upload_count(state: &AppState) -> usize {
-    state
-        .jobs
-        .read()
-        .ok()
-        .map(|jobs| {
-            jobs.values()
-                .filter(|job| matches!(job.status, JobStatus::AwaitingUpload))
-                .count()
-        })
-        .unwrap_or(0)
+/// Insert `job` unless the pending-upload cap is already reached, counting and
+/// inserting under a single write lock. Returns false when the job was refused.
+///
+/// This cap is separate from `admission_semaphore`: a job awaiting its upload
+/// holds no admission permit, so the two limits bound different things and both
+/// use `GTFS_VALIDATOR_WEB_MAX_QUEUED_JOBS` as their size.
+fn insert_job_within_pending_cap(state: &AppState, job: Job) -> bool {
+    let job_id = job.id.clone();
+    let inserted = {
+        let Ok(mut jobs) = state.jobs.write() else {
+            return false;
+        };
+        let pending = jobs
+            .values()
+            .filter(|existing| matches!(existing.status, JobStatus::AwaitingUpload))
+            .count();
+        if matches!(job.status, JobStatus::AwaitingUpload) && pending >= state.max_queued_jobs {
+            false
+        } else {
+            jobs.insert(job_id.clone(), job);
+            true
+        }
+    };
+    if inserted {
+        persist_job_metadata(state, job_id.as_str());
+    }
+    inserted
+}
+
+/// True when the request declares a body larger than the cap. A missing or
+/// unparsable `Content-Length` is not a rejection: the streaming write enforces
+/// the cap regardless of what the client declared.
+fn declared_length_over_cap(headers: &HeaderMap, max_bytes: usize) -> bool {
+    headers
+        .get(header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .is_some_and(|declared| declared > max_bytes as u64)
 }
 
 fn pubsub_token_matches(state: &AppState, headers: &HeaderMap) -> bool {
     let Some(expected) = state.pubsub_token.as_deref() else {
         return false;
     };
-    extract_pubsub_token(headers).is_some_and(|value| value == expected)
+    extract_pubsub_token(headers).is_some_and(|value| constant_time_eq(value, expected))
+}
+
+/// Compare two secrets without an early return, so response time does not leak
+/// how many leading bytes a guess got right. Length still differs observably,
+/// which is not sensitive for a fixed-length deployment token.
+fn constant_time_eq(left: &str, right: &str) -> bool {
+    let (left, right) = (left.as_bytes(), right.as_bytes());
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut difference = 0u8;
+    for (a, b) in left.iter().zip(right.iter()) {
+        difference |= a ^ b;
+    }
+    difference == 0
 }
 
 fn extract_pubsub_token(headers: &HeaderMap) -> Option<&str> {
@@ -1753,6 +1793,40 @@ mod tests {
             header::HeaderValue::from_static("Basic nope"),
         );
         assert_eq!(extract_pubsub_token(&headers), None);
+    }
+
+    #[test]
+    fn constant_time_eq_matches_string_equality() {
+        assert!(constant_time_eq("secret", "secret"));
+        assert!(!constant_time_eq("secret", "secreT"));
+        assert!(!constant_time_eq("secret", "secrets"));
+        assert!(!constant_time_eq("", "s"));
+        assert!(constant_time_eq("", ""));
+    }
+
+    #[test]
+    fn declared_length_over_cap_only_rejects_a_declared_overflow() {
+        let mut headers = HeaderMap::new();
+        assert!(!declared_length_over_cap(&headers, 10));
+
+        headers.insert(
+            header::CONTENT_LENGTH,
+            header::HeaderValue::from_static("10"),
+        );
+        assert!(!declared_length_over_cap(&headers, 10));
+
+        headers.insert(
+            header::CONTENT_LENGTH,
+            header::HeaderValue::from_static("11"),
+        );
+        assert!(declared_length_over_cap(&headers, 10));
+
+        // Chunked uploads declare nothing; the streaming write is the guard.
+        headers.insert(
+            header::CONTENT_LENGTH,
+            header::HeaderValue::from_static("not-a-number"),
+        );
+        assert!(!declared_length_over_cap(&headers, 10));
     }
 
     #[test]

--- a/deploy/hetzner-setup.sh
+++ b/deploy/hetzner-setup.sh
@@ -96,6 +96,11 @@ services:
       - GTFS_VALIDATOR_WEB_BASE_DIR=/data/jobs
       - GTFS_VALIDATOR_WEB_PUBLIC_BASE_URL=${PUBLIC_URL:-http://localhost:3000}
       - GTFS_VALIDATOR_WEB_JOB_TTL_SECONDS=86400
+      - GTFS_VALIDATOR_MAX_MEMBER_BYTES=268435456
+      - GTFS_VALIDATOR_MAX_TOTAL_BYTES=402653184
+      - GTFS_VALIDATOR_WEB_MAX_UPLOAD_BYTES=268435456
+      - GTFS_VALIDATOR_WEB_MAX_CONCURRENT_JOBS=2
+      - GTFS_VALIDATOR_WEB_MAX_CONCURRENT_UPLOADS=2
       - RUST_LOG=info
     volumes:
       - gtfs-data:/data/jobs
@@ -155,7 +160,7 @@ $DOMAIN {
     }
     
     request_body {
-        max_size 500MB
+        max_size 256MiB
     }
 }
 CADDYFILE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,10 @@ services:
     restart: unless-stopped
 
     ports:
-      - "3000:3000"
+      # Bind loopback only. Publishing 0.0.0.0:3000 bypasses host firewalls
+      # (UFW does not filter Docker-published ports). Caddy still reaches the
+      # service as gtfs-validator:3000 on the compose network.
+      - "127.0.0.1:3000:3000"
 
     environment:
       # Base directory for storing validation jobs
@@ -22,6 +25,13 @@ services:
       - GTFS_VALIDATOR_WEB_PUBLIC_BASE_URL=https://gtfs.yourdomain.com
       # Job TTL in seconds (default: 24 hours)
       - GTFS_VALIDATOR_WEB_JOB_TTL_SECONDS=86400
+      # Caps sized for the 2G memory limit below. Library defaults (4 GiB /
+      # 8 GiB) are for the CLI on larger hosts; do not use them here.
+      - GTFS_VALIDATOR_MAX_MEMBER_BYTES=268435456
+      - GTFS_VALIDATOR_MAX_TOTAL_BYTES=402653184
+      - GTFS_VALIDATOR_WEB_MAX_UPLOAD_BYTES=268435456
+      - GTFS_VALIDATOR_WEB_MAX_CONCURRENT_JOBS=2
+      - GTFS_VALIDATOR_WEB_MAX_CONCURRENT_UPLOADS=2
       # Logging level
       - RUST_LOG=info
 

--- a/docs/agents/web-api.md
+++ b/docs/agents/web-api.md
@@ -12,7 +12,9 @@
 - `GTFS_VALIDATOR_WEB_PUBLIC_BASE_URL` sets the base URL used for upload/report links.
 - `GTFS_VALIDATOR_WEB_MAX_UPLOAD_BYTES` caps streamed upload and URL-download size (default: 512 MiB).
 - `GTFS_VALIDATOR_WEB_MAX_CONCURRENT_JOBS` caps concurrent validations (default: 4).
-- `GTFS_VALIDATOR_WEB_MAX_QUEUED_JOBS` caps admitted jobs, including pending uploads (default: 64).
+- `GTFS_VALIDATOR_WEB_MAX_QUEUED_JOBS` sizes two separate caps (default: 64 each):
+  jobs queued or running, and jobs awaiting an upload. A job awaiting its upload
+  holds no admission permit, so the two are counted independently.
 - `GTFS_VALIDATOR_WEB_MAX_CONCURRENT_UPLOADS` caps concurrent upload streams (default: 4).
 - `GTFS_VALIDATOR_WEB_MAX_CREATE_JOB_REQUESTS_PER_MINUTE` rate-limits `POST /create-job` (default: 60).
 - `GTFS_VALIDATOR_WEB_PROCESSING_TIMEOUT_SECONDS` reclaims jobs stuck in `Processing` (default: 1800).
@@ -33,8 +35,10 @@
   browser UI. Private/reserved addresses and cross-site browser requests are rejected.
 - `POST /create-job` creates a job. Optional JSON body supports `countryCode` and `url`.
   Returns 429 when the create-job rate limit or pending-upload cap is hit.
-- `PUT /upload/:job_id` streams a GTFS zip to disk. The job is claimed before
-  the body is read, so a missing id returns 404 without buffering the upload.
+- `PUT /upload/:job_id` streams a GTFS zip to disk. A `Content-Length` over the
+  cap is refused with 413 before the job is claimed; the job is then claimed
+  before the body is read, so a missing id returns 404 without buffering the
+  upload. A body that exceeds the cap while streaming also returns 413.
 - `POST /run-validator` is the optional Pub/Sub restart hook and requires
   `GTFS_VALIDATOR_WEB_PUBSUB_TOKEN`.
 - `GET /jobs/:job_id/status` returns status and report URLs.

--- a/docs/agents/web-api.md
+++ b/docs/agents/web-api.md
@@ -3,12 +3,24 @@
 ## Scope
 
 - Axum-based HTTP service that runs the validator and serves report artifacts.
-- Runs on `0.0.0.0:3000` by default.
+- Listens on `0.0.0.0:3000` inside the process. Production Compose binds that
+  port to `127.0.0.1` on the host and puts Caddy in front.
 
 ## Configuration
 
 - `GTFS_VALIDATOR_WEB_BASE_DIR` sets the job workspace directory (default: `target/web_jobs`).
 - `GTFS_VALIDATOR_WEB_PUBLIC_BASE_URL` sets the base URL used for upload/report links.
+- `GTFS_VALIDATOR_WEB_MAX_UPLOAD_BYTES` caps streamed upload and URL-download size (default: 512 MiB).
+- `GTFS_VALIDATOR_WEB_MAX_CONCURRENT_JOBS` caps concurrent validations (default: 4).
+- `GTFS_VALIDATOR_WEB_MAX_QUEUED_JOBS` caps admitted jobs, including pending uploads (default: 64).
+- `GTFS_VALIDATOR_WEB_MAX_CONCURRENT_UPLOADS` caps concurrent upload streams (default: 4).
+- `GTFS_VALIDATOR_WEB_MAX_CREATE_JOB_REQUESTS_PER_MINUTE` rate-limits `POST /create-job` (default: 60).
+- `GTFS_VALIDATOR_WEB_PROCESSING_TIMEOUT_SECONDS` reclaims jobs stuck in `Processing` (default: 1800).
+- `GTFS_VALIDATOR_WEB_PUBSUB_TOKEN` is required for `POST /run-validator`. Send it as
+  `x-pubsub-token` or `Authorization: Bearer ...`. Unset or empty → 401.
+- `GTFS_VALIDATOR_MAX_MEMBER_BYTES` / `GTFS_VALIDATOR_MAX_TOTAL_BYTES` cap zip
+  inflation in the core loader (library defaults 4 GiB / 8 GiB). The 2 GiB
+  Compose file lowers these.
 - `GTFS_VALIDATOR_WEB_MAX_PROXY_BYTES` caps CORS-proxy responses (default: 70 MiB).
 - `GTFS_VALIDATOR_WEB_MAX_CONCURRENT_PROXY_REQUESTS` caps concurrent proxy fetches (default: 4).
 - `GTFS_VALIDATOR_WEB_MAX_PROXY_REQUESTS_PER_MINUTE` applies a global proxy rate limit (default: 60).
@@ -20,7 +32,11 @@
 - `GET /cors-proxy?url=<percent-encoded-url>` fetches a public HTTP(S) URL for the same-origin
   browser UI. Private/reserved addresses and cross-site browser requests are rejected.
 - `POST /create-job` creates a job. Optional JSON body supports `countryCode` and `url`.
-- `PUT /upload/:job_id` uploads a GTFS zip as raw bytes.
+  Returns 429 when the create-job rate limit or pending-upload cap is hit.
+- `PUT /upload/:job_id` streams a GTFS zip to disk. The job is claimed before
+  the body is read, so a missing id returns 404 without buffering the upload.
+- `POST /run-validator` is the optional Pub/Sub restart hook and requires
+  `GTFS_VALIDATOR_WEB_PUBSUB_TOKEN`.
 - `GET /jobs/:job_id/status` returns status and report URLs.
 - `GET /jobs/:job_id/report.json`, `/report.html`, `/system_errors.json` return artifacts.
 


### PR DESCRIPTION
Follow-ups from the review of the zip/upload hardening work.

**Uploads.** `PUT /upload/:job_id` streams from the raw `Request`, so the
`DefaultBodyLimit` layer on that route no longer did anything — axum applies it
only in extractors that call `into_limited_body`. The cap was still enforced
while streaming, so nothing was open, but the layer read like protection it did
not give. It is gone, and a `Content-Length` over the cap is refused with 413
before the job is claimed: an oversized upload now costs neither a job id nor a
byte of body.

**Job admission.** `create_job` counted pending uploads and then inserted, so
two concurrent creates could both see the last free slot and both take it.
Counting and inserting now happen under one write lock. The two caps sized by
`GTFS_VALIDATOR_WEB_MAX_QUEUED_JOBS` are documented for what they are: jobs
awaiting an upload hold no admission permit, so they are bounded separately
rather than sharing one budget as the docs claimed.

**Decompression limits.** These were recognised by searching `io::Error` text
for "per-file limit" and "total decompression limit" — tying classification to
the wording of two `format!` calls, and on the WASM path reading a `csv::Error`
string that can carry record data. A `LimitExceeded` sentinel now carries the
reason by value, recovered with `downcast_ref`; where a CSV parser flattens the
error into a string, the reason is read off the reader's own flag instead.

**Header window.** The single-threaded header pass truncated at 64 KiB in
silence. A member whose first line ran past that produced a header cut
mid-field, which was accepted, while the second pass read the real, longer
header — so rows were validated against columns the `RowValidator` never saw.
The window is now 1 MiB and hitting it is an error.

**Buffer growth.** Routing directory reads through `CappedReader` cost them
`File::read_to_end`'s size-based preallocation, so the buffer grew by doubling.
The real size is passed back in as a capacity hint; the zip path does not get
one, because a member's declared size is written by whoever built the archive.

Also: constant-time comparison for the Pub/Sub token, and `zip_member_too_large`
renamed to `member_too_large` so the message stops calling a file on disk an
uncompressed zip member.

## Testing

471 workspace tests pass; clippy clean with and without `parallel`; `cargo fmt
--all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
