### PR TITLE
Implementation of GTF-30: to make README.md more concise and readable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## I Have a Question
 
-> If you want to ask a question, we assume that you have read the available [Documentation](https://gtfs.guru).
+> If you want to ask a question, we assume that you have read the available [Documentation](https://abasis-ltd.github.io/gtfs.guru).
 
 Before you ask a question, it is best to search for existing [Issues](https://github.com/abasis-ltd/gtfs.guru/issues) that might help you. In case you've found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,19 +72,56 @@ You will need [Rust](https://www.rust-lang.org/tools/install) installed. We reco
 
 See [`docs/system-dependencies.md`](docs/system-dependencies.md) for the package list.
 
-### Building parts of the project
+### Project layout
 
-The project is a workspace with multiple crates.
+This monorepo houses the whole ecosystem. `gtfs_validator_core` is the
+validation engine; every front-end is a thin wrapper around it and
+`gtfs_validator_report`:
 
-- Core logic: `crates/gtfs_validator_core`
-- CLI tool: `crates/gtfs_validator_cli`
-- Web view: `crates/gtfs_validator_web`
+```mermaid
+graph LR
+    model["gtfs_model<br/>shared GTFS types"] --> core["gtfs_validator_core<br/>110 validators"]
+    core --> report["gtfs_validator_report<br/>JSON · HTML · SARIF"]
+    core --> profile["gtfs_validator_profile<br/>deterministic feed facts"]
+    report --> cli["gtfs_validator_cli<br/>gtfs-guru binary"]
+    profile --> cli
+    profile --> mcp["gtfs_validator_mcp<br/>MCP server"]
+    report --> web["gtfs_validator_web<br/>Axum API server"]
+    report --> gui["gtfs_validator_gui<br/>Tauri desktop app"]
+    report --> wasm["gtfs_validator_wasm<br/>browser bindings"]
+    report --> python["gtfs_validator_python<br/>PyO3 bindings"]
+```
 
-To build the entire workspace:
+| Crate | Role |
+| --- | --- |
+| [`crates/gtfs_model`](crates/gtfs_model) | Shared GTFS data model types |
+| [`crates/gtfs_validator_core`](crates/gtfs_validator_core) | The validation engine (110 validators) |
+| [`crates/gtfs_validator_report`](crates/gtfs_validator_report) | Report generation (JSON / HTML / SARIF) |
+| [`crates/gtfs_validator_profile`](crates/gtfs_validator_profile) | Deterministic feed facts behind `profile` and `explain` |
+| [`crates/gtfs_validator_cli`](crates/gtfs_validator_cli) | The `gtfs-guru` command-line tool |
+| [`crates/gtfs_validator_mcp`](crates/gtfs_validator_mcp) | Read-only MCP server for LLM clients |
+| [`crates/gtfs_validator_web`](crates/gtfs_validator_web) | Web API service (Axum) |
+| [`crates/gtfs_validator_gui`](crates/gtfs_validator_gui) | Desktop application (Tauri) |
+| [`crates/gtfs_validator_python`](crates/gtfs_validator_python) | Python bindings (PyO3 / Maturin) |
+| [`crates/gtfs_validator_wasm`](crates/gtfs_validator_wasm) | WebAssembly bindings for the browser |
+
+### Building
+
+Build the entire workspace:
 
 ```bash
 cargo build
 ```
+
+Or just one crate, which is much faster:
+
+```bash
+cargo build --release -p gtfs-guru
+```
+
+Per-crate implementation notes for contributors live in
+[`docs/agents/`](docs/agents), and the repository-wide conventions in
+[`AGENTS.md`](AGENTS.md).
 
 ### Running Tests
 

--- a/README.md
+++ b/README.md
@@ -1,379 +1,160 @@
-# GTFS Guru 🚀
+<div align="center">
+
+<img src="gtfs-guru-mark.png" alt="GTFS Guru" width="120">
+
+# GTFS Guru
+
+**A fast, native, multi-platform GTFS validator.**
 
 [![CI](https://github.com/abasis-ltd/gtfs.guru/actions/workflows/rust.yml/badge.svg)](https://github.com/abasis-ltd/gtfs.guru/actions)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Crates.io](https://img.shields.io/crates/v/gtfs-guru.svg)](https://crates.io/crates/gtfs-guru)
 [![PyPI](https://img.shields.io/pypi/v/gtfs-guru.svg)](https://pypi.org/project/gtfs-guru/)
 
-**A fast, native, multi-platform GTFS validator.**
+[Try it in your browser](https://gtfs.guru) · [Documentation](https://abasis-ltd.github.io/gtfs.guru/) · [Download](https://github.com/abasis-ltd/gtfs.guru/releases/latest)
 
-GTFS Guru is a next-generation tool to check your transit data (GTFS) for errors. It ensures your schedules, routes, and stops are correct before they go live on Google Maps, Apple Maps, or other journey planners.
-
-> 💡 **Inspired by [MobilityData/gtfs-validator](https://github.com/MobilityData/gtfs-validator)**. We rebuilt the validation logic from the ground up in Rust to achieve blazing speed, privacy, and universal portability.
+</div>
 
 ---
 
-## 🌟 Why GTFS Guru?
+GTFS Guru checks your transit data for errors before it goes live on Google
+Maps, Apple Maps, or any other journey planner — 110 validators over your
+schedules, routes, stops, fares, and shapes, in seconds, on your own machine.
 
-1. **Fast native engine**: Parallel CSV loading and validation keep large feeds in the seconds range, with no JVM startup cost.
-2. **Privacy First**: Runs locally on your machine. No need to upload sensitive or pre-release schedules to the cloud.
-3. **Cross-Platform**: Available as a desktop app, command-line tool, Python library, Web API, and WebAssembly module.
-4. **CI & Integrations**: JSON/HTML/SARIF reports, notice schema export, URL validation, and timing breakdowns.
-5. **Deep Coverage**: 110 validators, Google-specific rules, and an optional `--thorough` mode.
+> [!NOTE]
+> Inspired by [MobilityData/gtfs-validator](https://github.com/MobilityData/gtfs-validator).
+> We rebuilt the validation logic from the ground up in Rust for speed, privacy,
+> and portability. The report shape and notice codes are closely compatible; the
+> rule sets are not identical.
 
-| Feature | Java Validator | **GTFS Guru (Rust)** |
-| :--- | :---: | :---: |
-| **Speed** | JVM startup + Java pipeline | Native binary; see benchmarks below |
-| **Memory** | 🐘 Heavy (JVM) | 🪶 **Light (Native)** |
-| **Platform** | Java Runtime Required | **Standalone Binary** |
-| **Python** | ❌ Wrapper only | ✅ **Native (`pip install`)** |
-| **Web** | ❌ Server-side only | ✅ **Browser-native (WASM)** |
-| **CI Output** | ❌ | ✅ **SARIF + JSON/HTML** |
+## Why GTFS Guru?
 
----
+- **Fast native engine** — parallel CSV loading keeps even 16-million-row feeds in the seconds range, with no JVM startup cost.
+- **Private by default** — runs locally. Pre-release schedules never leave your machine.
+- **Everywhere you work** — desktop app, CLI, Python library, Web API, WebAssembly, and an MCP server for LLM clients.
+- **Built for CI** — SARIF, JSON, and HTML reports, status badges, exit codes, and a ready-made GitHub Action.
+- **Deep coverage** — 110 validators, optional Google-specific rules, and a `--thorough` mode.
+- **Fixes, not just complaints** — `--fix` writes a repaired copy of the feed and validates it again.
 
-## 📌 Versions
+| | Java Validator | GTFS Guru |
+| :--- | :--- | :--- |
+| **Speed** | JVM startup + Java pipeline | Native binary, [4.6–6.7× faster](docs/benchmarks.md) |
+| **Memory** | 🐘 Heavy (JVM) | 🪶 Light (native) |
+| **Platform** | Java runtime required | Standalone binary |
+| **Python** | Wrapper only | Native (`pip install`) |
+| **Browser** | Server-side only | Browser-native (WASM) |
+| **CI output** | — | SARIF + JSON/HTML + badges |
 
-* Current engine/CLI/report/model/python/wasm/web crate versions: **`v1.0.0`**
-* Desktop app releases are tagged on GitHub; download the latest for your OS.
+## Install
 
----
+**Desktop app** — download the installer for macOS, Windows, or Linux from the
+[releases page](https://github.com/abasis-ltd/gtfs.guru/releases/latest), then
+drag your `gtfs.zip` onto the window. No command line involved.
 
-## 📥 Installation
-
-### 👨‍💼 For Non-Developers (Desktop App)
-
-The easiest way to validate feeds without using the command line.
-
-1. Go to the [**Releases Page**](https://github.com/abasis-ltd/gtfs.guru/releases/latest).
-2. Download the installer for your OS (these links always point to the latest release):
-    * 🍎 **macOS (DMG)**: [`gtfs-guru-macos.dmg`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-macos.dmg)
-    * 🪟 **Windows (x64)**: [`gtfs-guru-windows-x64.msi`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-windows-x64.msi) or [`gtfs-guru-windows-x64-setup.exe`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-windows-x64-setup.exe)
-    * 🐧 **Linux (Debian)**: [`gtfs-guru-linux-amd64.deb`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-linux-amd64.deb)
-    * 🐧 **Linux (AppImage)**: [`gtfs-guru-linux-amd64.AppImage`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-linux-amd64.AppImage)
-3. Run the installer and launch the app. Drag and drop your `gtfs.zip` file to validate!
-
-### 🐍 For Python Developers (Data Science)
-
-Perfect for checking data integrity within Jupyter Notebooks or ETL pipelines (Python 3.8+).
-
-```bash
-pip install gtfs-guru
-```
-
-```python
-import gtfs_guru
-
-# Validate a feed and return a rich report object
-report = gtfs_guru.validate("path/to/gtfs.zip")
-
-print(f"Valid: {report.is_valid}")
-print(f"Notices: {len(report.notices)}")
-
-# Export results
-report.save_html("validation_report.html")
-report.save_json("report.json")
-```
-
-### 🧰 For CLI Users (Prebuilt Binaries)
-
-Download the latest CLI for your platform:
-
-* 🍎 **macOS (arm64)**: [`gtfs-guru-macos-arm64.tar.gz`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-macos-arm64.tar.gz)
-* 🍎 **macOS (x86_64)**: [`gtfs-guru-macos-x86_64.tar.gz`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-macos-x86_64.tar.gz)
-* 🐧 **Linux (x86_64, glibc/gnu)**: [`gtfs-guru-linux-x86_64.tar.gz`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-linux-x86_64.tar.gz)
-* 🐧 **Linux (x86_64, musl)**: [`gtfs-guru-linux-x86_64-musl.tar.gz`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-linux-x86_64-musl.tar.gz)
-* 🐧 **Linux (arm64)**: [`gtfs-guru-linux-aarch64.tar.gz`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-linux-aarch64.tar.gz)
-* 🪟 **Windows (x64)**: [`gtfs-guru-windows-x64.zip`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-windows-x64.zip)
-
-**One-liner (macOS/Linux):**
+**Command line** — macOS and Linux:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/abasis-ltd/gtfs.guru/main/scripts/install.sh | bash
 ```
 
-**One-liner (Windows PowerShell):**
+Windows PowerShell:
 
 ```powershell
 iwr -useb https://raw.githubusercontent.com/abasis-ltd/gtfs.guru/main/scripts/install.ps1 | iex
 ```
 
-Optional env vars:
-* `INSTALL_DIR=/custom/bin`
-* `GTFS_GURU_LINUX_FLAVOR=gnu|musl` (x86_64 Linux only)
-* `GTFS_GURU_VERSION=v1.0.0`
-
-**CI examples (GitHub Actions):**
-
-Use the action — it installs a checksum-verified binary, runs the validation,
-sends SARIF to the Security tab, and fails the job on a bad feed:
-
-```yaml
-jobs:
-  validate:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: abasis-ltd/gtfs.guru/action@v1
-        with:
-          feed: feed.zip
-          fail-on: error
-```
-
-Full input/output reference: [`action/README.md`](action/README.md).
-
-Or drive the CLI yourself:
-
-```yaml
-jobs:
-  validate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install gtfs-guru
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/abasis-ltd/gtfs.guru/main/scripts/install.sh | bash
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-      - name: Run validation
-        run: gtfs-guru -i feed.zip -o out --fail-on error
-```
-
-**CI examples (GitLab CI):**
-
-```yaml
-validate:
-  image: ubuntu:22.04
-  before_script:
-    - apt-get update && apt-get install -y ca-certificates curl
-    - curl -fsSL https://raw.githubusercontent.com/abasis-ltd/gtfs.guru/main/scripts/install.sh | bash
-    - export PATH="$HOME/.local/bin:$PATH"
-  script:
-    - gtfs-guru -i feed.zip -o out --fail-on error
-```
-
-### 🦀 For Rust Developers (CLI)
-
-The classic high-performance command-line interface.
-
-**From Crates.io:**
+**Python** — for notebooks and ETL pipelines (Python 3.8+):
 
 ```bash
-cargo install gtfs-guru
+pip install gtfs-guru
 ```
 
-**Build from Source:**
+Also available with `cargo install gtfs-guru`. Every platform archive, the
+installer's environment variables, and building from source are in the
+[installation guide](docs/installation.md).
+
+## Quick start
+
+```bash
+# Validate a feed; writes report.json, report.html, and system_errors.json
+gtfs-guru -i gtfs.zip -o ./report
+
+# Validate straight from a URL
+gtfs-guru -u https://example.com/gtfs.zip -o ./report
+
+# Fail a CI job on any error, and hand SARIF to your code scanner
+gtfs-guru -i gtfs.zip -o ./report --fail-on error --sarif gtfs.sarif.json
+
+# See what a repair would change, then write a fixed copy
+gtfs-guru -i gtfs.zip -o ./report --fix-dry-run
+gtfs-guru -i gtfs.zip -o ./report --fix
+
+# Compare a feed update and fail on new errors
+gtfs-guru diff old.zip new.zip --fail-on-new-errors
+```
+
+```python
+import gtfs_guru
+
+report = gtfs_guru.validate("gtfs.zip")
+print(f"Valid: {report.is_valid}, notices: {len(report.notices)}")
+report.save_html("validation_report.html")
+```
+
+Validate on every push with the bundled GitHub Action:
+
+```yaml
+- uses: actions/checkout@v4
+- uses: abasis-ltd/gtfs.guru/action@v1
+  with:
+    feed: feed.zip
+    fail-on: error
+```
+
+Full option list, subcommands, badges, and CI recipes: [**usage guide**](docs/usage.md).
+
+## Performance
+
+Apple M3 Pro, warm page cache, each tool writing its normal report files:
+
+| Feed | `stop_times.txt` rows | `gtfs.guru` | `gtfsvtor` 1.0.3 | canonical `gtfs-validator` 8.0.1 |
+| :--- | ---: | ---: | ---: | ---: |
+| MBTA Boston | 5.4M | **2.32 s** | 6.13 s | 10.60 s |
+| OVapi NL | 16.0M | **9.75 s** | 21.66 s | 65.18 s |
+
+Setup, caveats, and commands to reproduce: [**benchmarks**](docs/benchmarks.md).
+
+## Documentation
+
+| Guide | What's in it |
+| --- | --- |
+| [Installation](docs/installation.md) | Every platform, installer flags, building from source |
+| [Usage](docs/usage.md) | CLI options, `diff` / `profile` / `explain`, exit codes, badges, CI |
+| [Benchmarks](docs/benchmarks.md) | Method, numbers, and how to reproduce them |
+| [LLM Guide](docs/llm.md) | Compact copy/paste reference and the MCP server |
+| [Python API](docs/python_api.md) | The `gtfs_guru` module |
+| [Validation Rules](docs/rules.md) | Every notice code the 110 validators emit |
+| [Browser (WASM)](docs/wasm.md) | Running the validator client-side |
+
+## Contributing
+
+Contributions are very welcome — new rules, bug fixes, documentation.
 
 ```bash
 git clone https://github.com/abasis-ltd/gtfs.guru
 cd gtfs.guru
-cargo build --release -p gtfs-guru
+cargo test --workspace
 ```
 
----
+You will need [Rust](https://rustup.rs); on Linux, also the
+[system dependencies](docs/system-dependencies.md). See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the project layout, the review workflow,
+and the style guide, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community
+expectations.
 
-## ⚡ Usage (CLI)
+Found a security issue? Please follow [SECURITY.md](SECURITY.md) rather than
+opening a public issue.
 
-Validate a feed and output the report to a directory:
+## License
 
-```bash
-gtfs-guru -i /path/to/gtfs.zip -o ./output_report
-```
-
-Validate from a URL (with an optional download cache):
-
-```bash
-gtfs-guru -u https://example.com/gtfs.zip -s /tmp/gtfs -o ./output_report
-```
-
-Compare a feed update, including routes, stops, trip/frequency aggregates, and
-validation regressions:
-
-```bash
-gtfs-guru diff old.zip new.zip
-gtfs-guru diff old.zip new.zip --json diff.json --markdown diff.md --fail-on-new-errors
-```
-
-The diff command exits with status `2` under `--fail-on-new-errors` when the new
-feed adds error occurrences. Use `--no-validation` for a faster structural-only
-comparison.
-
-Generate deterministic facts or a human-readable explanation:
-
-```bash
-gtfs-guru profile -i feed.zip --date 2026-07-27 --pretty
-gtfs-guru explain -i feed.zip --date 2026-07-27
-gtfs-guru explain -i feed.zip --json --pretty
-```
-
-The profile includes entity counts, route types, completeness facts, seven
-actual service dates with calendar exceptions applied, and grouped validation
-issues. The explanation is derived from the same profile, so every statement
-can be checked without sending the feed to an LLM provider.
-
-See exactly which standard a build answers for — the files, fields, enum values,
-and notice codes it supports, and the specification revision and canonical
-validator release it was checked against:
-
-```bash
-gtfs-guru spec-surface --pretty
-gtfs-guru -i feed.zip --stdout | jq '.summary | {specRevision, canonicalBaseline}'
-```
-
-### MCP server
-
-Build the read-only MCP server. The default stdio transport is suitable for a
-local Claude/ChatGPT-compatible MCP host:
-
-```bash
-cargo build --release -p gtfs-guru-mcp
-./target/release/gtfs-guru-mcp --allow-dir /path/to/feeds
-```
-
-It exposes `list_gtfs_feeds`, `validate_gtfs`, `explain_gtfs`, and
-`get_notice_details`. `list_gtfs_feeds` reports the feeds under the allowed
-roots with the absolute path the other tools take, so an assistant asked about
-a feed by name can find it without searching the filesystem. Validation
-responses include exact grouped totals plus up to three concrete examples per
-code/severity group with available file, row, field, context, and suggested
-fixes. Local file access is restricted to configured roots. Public URL
-downloads are disabled by default and can be explicitly enabled with
-`--allow-url`.
-
-After an in-browser validation, gtfs.guru also renders a local “What ChatGPT
-receives” preview from the same report. It demonstrates the MCP payload without
-uploading the feed or calling an AI provider.
-
-For a remote MCP client, start authenticated stateless Streamable HTTP:
-
-```bash
-export GTFS_GURU_MCP_BEARER_TOKEN="$(openssl rand -hex 32)"
-./target/release/gtfs-guru-mcp \
-  --transport http \
-  --bind 127.0.0.1:3000 \
-  --allow-dir /path/to/feeds \
-  --allow-url
-```
-
-The MCP endpoint is `/mcp`; `/healthz` is unauthenticated. Put public
-deployments behind TLS and pass each externally visible hostname with
-`--allowed-host`. HTTP defaults to 60 authenticated requests per rolling minute,
-four concurrent validations, and 64 KiB request bodies.
-
-Default outputs in the report directory:
-* `report.json`
-* `report.html`
-* `system_errors.json`
-
-Optional outputs:
-* `--sarif report.sarif.json`
-* `--badge badge.json` (a shields.io endpoint descriptor for a README badge)
-* `--export-notices-schema` (writes `notice_schema.json`)
-
-**Options (highlights):**
-* `-i, --input <FILE>`: Path to GTFS zip file or directory.
-* `-u, --url <URL>`: Validate a remote GTFS zip.
-* `-s, --storage_directory <DIR>`: Save downloaded feeds when using `--url`.
-* `-o, --output_base <DIR>`: Directory to save reports.
-* `--stdout`: Write only the JSON validation report to stdout instead of report files.
-* `--skip_validator_update`: Skip the online validator update check.
-* `--threads <N>`: Thread count recorded in the generated report.
-* `--google-rules`: Enable Google-specific rules.
-* `--thorough`: Enable recommended-field checks.
-* `--sarif <FILE>`: Write SARIF report for CI.
-* `--timing` / `--timing-json`: Print timing breakdowns.
-* `--fail-on <none|error|warning>`: Exit with status 2 when the report reaches that severity. Reports are still written.
-* `--badge <FILE>` / `--badge-svg <FILE>`: Write a status badge. See [Status badges](docs/usage.md#status-badges).
-
-`--fix-dry-run` lists suggested edits without touching anything. `--fix` applies the safe ones and `--fix-unsafe` applies all of them, writing a repaired copy to `--fix-output` (default: `<input>.fixed.<ext>` beside the input). The input is never modified and an existing output path is refused. Field repairs rewrite only their CSV records; sorting moves the original raw records, and every untouched file is copied byte for byte.
-
-Safe fixes cover whitespace, colors (`#FF0000`, `0F0`), dates written with separators, times missing their seconds, URLs missing a scheme, `mailto:`-wrapped emails, and canonical `stop_times.txt` ordering. Decimal commas need confirmation; deleting rows whose foreign key points at a missing parent is available only under `--fix-unsafe`. Syntactic replacements are re-validated before they are offered, ambiguous values (`01-05-2026`, `1,500`) get no suggestion, and the repaired feed is automatically validated again with resolved/remaining/introduced totals.
-
-Exit codes: `0` validation completed, `1` the run failed, `2` the feed did not meet `--fail-on`.
-
-See the [LLM Guide](docs/llm.md) for a compact, copy/paste reference.
-
-## ⚡ Performance
-
-Benchmarks below were run on an Apple M3 Pro with warm page cache. Each tool validates the feed end-to-end and writes its normal report files; stdout/stderr were redirected to `/dev/null` so terminal progress logging does not dominate the measurement.
-
-Setup:
-
-* `gtfs.guru` was built with `cargo build --release -p gtfs-guru` and run with `RAYON_NUM_THREADS=8`, `--threads 8`, and `--skip_validator_update`.
-* `mecatran/gtfsvtor` was v1.0.3, run on OpenJDK 21 with `--numThreads 8` and `GTFSVTOR_OPTS=-Xmx6G`.
-* The canonical `MobilityData/gtfs-validator` was v8.0.1, run on OpenJDK 21 with `--threads 8`, `--skip_validator_update`, and `-Xmx6G`.
-
-| Feed | Size | `gtfs.guru` | `gtfsvtor` 1.0.3 | canonical `gtfs-validator` 8.0.1 |
-| :--- | ---: | ---: | ---: | ---: |
-| MBTA Boston | 38 MB zip, 295 MB uncompressed, 5.4M `stop_times.txt` rows | **2.32 s** (n=5) | 6.13 s (n=3) | 10.60 s (n=3) |
-| OVapi NL 2026-06-09 | 198 MB zip, 1.27 GB uncompressed, 16.0M `stop_times.txt` rows | **9.75 s** (n=5) | 21.66 s (n=3) | 65.18 s (n=3) |
-
-On these feeds `gtfs.guru` is about 2.2-2.6x faster than `gtfsvtor`, and about 4.6-6.7x faster than the canonical Java validator. The comparison is wall-clock time for each tool doing its own full validation pipeline; rule sets and report formats differ, so this is not a per-rule apples-to-apples benchmark.
-
-Reproduce:
-
-```bash
-curl -sL -o /tmp/mbta.zip https://cdn.mbta.com/MBTA_GTFS.zip
-curl -L -o /tmp/NL-20260609.gtfs.zip https://gtfs.ovapi.nl/nl/NL-20260609.gtfs.zip
-
-RAYON_NUM_THREADS=8 gtfs-guru \
-  -i /tmp/NL-20260609.gtfs.zip \
-  -o /tmp/gtfs-guru-nl \
-  --skip_validator_update \
-  --threads 8
-
-java -Xmx6G -jar gtfs-validator-8.0.1-cli.jar \
-  -i /tmp/NL-20260609.gtfs.zip \
-  -o /tmp/gtfs-validator-nl \
-  --skip_validator_update \
-  --threads 8
-
-GTFSVTOR_OPTS=-Xmx6G gtfsvtor \
-  --numThreads 8 \
-  --htmlOutput /tmp/gtfsvtor-nl.html \
-  --jsonOutput /tmp/gtfsvtor-nl.json \
-  /tmp/NL-20260609.gtfs.zip
-```
-
----
-
-## 📂 Project Structure
-
-This monorepo houses the entire ecosystem. `gtfs_validator_core` is the
-validation engine; every front-end (CLI, web, GUI, WASM, Python) is a thin
-wrapper around it and `gtfs_validator_report`:
-
-```mermaid
-graph LR
-    model["gtfs_model<br/>shared GTFS types"] --> core["gtfs_validator_core<br/>110 validators"]
-    core --> report["gtfs_validator_report<br/>JSON · HTML · SARIF"]
-    report --> cli["gtfs_validator_cli<br/>gtfs-guru binary"]
-    report --> web["gtfs_validator_web<br/>Axum API server"]
-    report --> gui["gtfs_validator_gui<br/>Tauri desktop app"]
-    report --> wasm["gtfs_validator_wasm<br/>browser bindings"]
-    report --> python["gtfs_validator_python<br/>PyO3 bindings"]
-```
-
-* **`crates/gtfs_model`**: Shared GTFS data model types.
-* **`crates/gtfs_validator_core`**: The validation engine (110 validators).
-* **`crates/gtfs_validator_report`**: Report generation (JSON/HTML/SARIF).
-* **`crates/gtfs_validator_cli`**: CLI tool implementation.
-* **`crates/gtfs_validator_web`**: Web API service.
-* **`crates/gtfs_validator_gui`**: Desktop application (Tauri).
-* **`crates/gtfs_validator_python`**: Python bindings (via PyO3/Maturin).
-* **`crates/gtfs_validator_wasm`**: WebAssembly bindings for browser usage.
-
-## 🤝 Contributing
-
-We welcome contributions! Whether it's adding new rules, fixing bugs, or improving documentation.
-
-1. Clone the repo: `git clone https://github.com/abasis-ltd/gtfs.guru`
-2. Install Rust: [rustup.rs](https://rustup.rs)
-3. On Linux, install the system dependencies: see [`docs/system-dependencies.md`](docs/system-dependencies.md)
-4. Run tests: `cargo test --workspace`
-
-## 📄 License
-
-Apache-2.0. Free to use for everyone.
+[Apache-2.0](LICENSE). Free to use for everyone.

--- a/crates/gtfs_validator_mcp/README.md
+++ b/crates/gtfs_validator_mcp/README.md
@@ -24,6 +24,22 @@ stdio server, or run `--transport http` with `--bind` for HTTP access
 (requires a bearer token). Run `gtfs-guru-mcp --help` for the full option
 list.
 
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `list_gtfs_feeds` | Discover feeds under the `--allow-dir` roots, with the absolute path the other tools take |
+| `validate_gtfs` | Validate a feed and return exact grouped notice totals plus concrete examples |
+| `explain_gtfs` | A plain-language summary derived only from deterministic profile facts |
+| `get_notice_details` | Full description and severity of a single notice code |
+
+File access is confined to the `--allow-dir` roots. Public URL downloads are
+off unless you pass `--allow-url`.
+
+The [LLM Guide](https://abasis-ltd.github.io/gtfs.guru/llm/#mcp-server) has
+client configuration examples, the HTTP transport's limits, and the response
+shape.
+
 ## License
 
 Apache-2.0

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,62 @@
+# Benchmarks
+
+On the two large real-world feeds below, `gtfs.guru` is roughly **2.2–2.6× faster
+than `gtfsvtor`** and **4.6–6.7× faster than the canonical Java validator**.
+
+| Feed | Size | `gtfs.guru` | `gtfsvtor` 1.0.3 | canonical `gtfs-validator` 8.0.1 |
+| :--- | ---: | ---: | ---: | ---: |
+| MBTA Boston | 38 MB zip · 295 MB unpacked · 5.4M `stop_times.txt` rows | **2.32 s** (n=5) | 6.13 s (n=3) | 10.60 s (n=3) |
+| OVapi NL 2026-06-09 | 198 MB zip · 1.27 GB unpacked · 16.0M `stop_times.txt` rows | **9.75 s** (n=5) | 21.66 s (n=3) | 65.18 s (n=3) |
+
+!!! warning "What this does and does not measure"
+    These are wall-clock times for each tool running its own full validation
+    pipeline. Rule sets and report formats differ between the three validators,
+    so this is **not** a per-rule apples-to-apples comparison.
+
+## Setup
+
+Measured on an Apple M3 Pro with a warm page cache. Every tool validates the
+feed end-to-end and writes its normal report files; stdout and stderr were
+redirected to `/dev/null` so terminal progress logging does not dominate the
+measurement.
+
+| Tool | Version | Invocation |
+| --- | --- | --- |
+| `gtfs.guru` | built with `cargo build --release -p gtfs-guru` | `RAYON_NUM_THREADS=8`, `--threads 8`, `--skip_validator_update` |
+| [`mecatran/gtfsvtor`](https://github.com/mecatran/gtfsvtor) | 1.0.3 | OpenJDK 21, `--numThreads 8`, `GTFSVTOR_OPTS=-Xmx6G` |
+| [`MobilityData/gtfs-validator`](https://github.com/MobilityData/gtfs-validator) | 8.0.1 | OpenJDK 21, `--threads 8`, `--skip_validator_update`, `-Xmx6G` |
+
+## Reproducing
+
+```bash
+curl -sL -o /tmp/mbta.zip https://cdn.mbta.com/MBTA_GTFS.zip
+curl -L -o /tmp/NL-20260609.gtfs.zip https://gtfs.ovapi.nl/nl/NL-20260609.gtfs.zip
+```
+
+```bash
+RAYON_NUM_THREADS=8 gtfs-guru \
+  -i /tmp/NL-20260609.gtfs.zip \
+  -o /tmp/gtfs-guru-nl \
+  --skip_validator_update \
+  --threads 8
+```
+
+```bash
+java -Xmx6G -jar gtfs-validator-8.0.1-cli.jar \
+  -i /tmp/NL-20260609.gtfs.zip \
+  -o /tmp/gtfs-validator-nl \
+  --skip_validator_update \
+  --threads 8
+```
+
+```bash
+GTFSVTOR_OPTS=-Xmx6G gtfsvtor \
+  --numThreads 8 \
+  --htmlOutput /tmp/gtfsvtor-nl.html \
+  --jsonOutput /tmp/gtfsvtor-nl.json \
+  /tmp/NL-20260609.gtfs.zip
+```
+
+Note that `--threads` is report metadata kept for Java compatibility; it is
+`RAYON_NUM_THREADS` that sizes the thread pool. See
+[Parallelism](usage.md#parallelism).

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,11 @@ Closely compatible with [MobilityData gtfs-validator](https://github.com/Mobilit
 
 | Feature | Java Validator | GTFS.Guru |
 |---------|---------------|-----------|
-| **Speed** | 1x | 4.6–6.7x faster on published benchmarks |
+| **Speed** | 1x | [4.6–6.7x faster](benchmarks.md) |
 | **Startup** | JVM warm-up | Native binary, no runtime |
 | **Python bindings** | ❌ | ✅ |
 | **WebAssembly** | ❌ | ✅ |
+| **MCP server** | ❌ | ✅ |
 | **Parsing Strategy** | Serial | Parallel (Rayon) |
 | **Desktop app** | ❌ | ✅ |
 
@@ -33,13 +34,11 @@ print(f"Valid: {result.is_valid}, Errors: {result.error_count}")
 ### Command Line
 
 ```bash
-# Build
-cargo build --release -p gtfs-guru
+curl -fsSL https://raw.githubusercontent.com/abasis-ltd/gtfs.guru/main/scripts/install.sh | bash
+```
 
-# Run
-./target/release/gtfs-guru \
-    --input /path/to/gtfs.zip \
-    --output_base /tmp/report
+```bash
+gtfs-guru --input /path/to/gtfs.zip --output_base /tmp/report
 ```
 
 ### Web API
@@ -52,7 +51,7 @@ cargo run --release -p gtfs-guru-web
 ## Features
 
 - **110 validation rules** — broad coverage including Fares v2, Flex and Pathways
-- **Multiple interfaces** — CLI, Web API, Python bindings, Desktop App, WebAssembly
+- **Multiple interfaces** — CLI, Web API, Python bindings, Desktop App, WebAssembly, MCP
 - **Cross-platform** — macOS, Linux, Windows
 - **Detailed reports** — JSON, HTML and SARIF output with geographic context
 - **Auto-fix** — `--fix-dry-run` lists suggested edits, `--fix` writes a repaired copy of the feed
@@ -61,6 +60,8 @@ cargo run --release -p gtfs-guru-web
 ## Next Steps
 
 - [Installation](installation.md) — Install via pip, cargo, or download binaries
-- [CLI Usage](usage.md) — Command-line options and examples
+- [CLI Usage](usage.md) — Command-line options, subcommands, and CI recipes
+- [Benchmarks](benchmarks.md) — How the speed numbers were measured
+- [LLM Guide](llm.md) — Copy/paste reference and the MCP server
 - [Python API](python_api.md) — Python bindings documentation
 - [Validation Rules](rules.md) — Notice codes emitted by the 110 validators

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,25 +1,42 @@
 # Installation
 
-## From Source (Rust)
+Pick the front-end that matches how you work:
 
-On Linux, install the system dependencies first – see [System Dependencies](system-dependencies.md).
+| You want to… | Install | Section |
+| --- | --- | --- |
+| Drag a `gtfs.zip` onto a window | Desktop app | [Desktop app](#desktop-app) |
+| Validate from a terminal or CI job | CLI binary | [Command-line tool](#command-line-tool) |
+| Check feeds inside a notebook or ETL job | `pip install gtfs-guru` | [Python package](#python-package) |
+| Let an LLM client validate feeds | MCP server | [MCP server](#mcp-server) |
+| Build from a checkout | `cargo build` | [From source](#from-source-rust) |
 
-```bash
-git clone https://github.com/abasis-ltd/gtfs.guru
-cd gtfs.guru
-cargo build --release
-```
+!!! info "Versioning"
+    The engine, CLI, report, model, profile, MCP, Python, WASM, and web crates
+    are versioned and released together, so a `gtfs-guru` you install from any
+    channel reports the same version. Desktop app builds are tagged on GitHub.
+    The current number is on
+    [crates.io](https://crates.io/crates/gtfs-guru) and in
+    `gtfs-guru --version`.
 
-Binaries will be in `target/release/`:
+## Desktop app
 
-- `gtfs-guru` — command-line tool
-- `gtfs-guru-web` — web server
+The easiest way to validate a feed without touching a command line. Download the
+installer for your OS from the
+[latest release](https://github.com/abasis-ltd/gtfs.guru/releases/latest) — these
+links always resolve to the newest build:
 
-## Prebuilt binaries
+| Platform | Download |
+| --- | --- |
+| 🍎 macOS | [`gtfs-guru-macos.dmg`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-macos.dmg) |
+| 🪟 Windows (x64) | [`gtfs-guru-windows-x64.msi`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-windows-x64.msi) · [`…-setup.exe`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-windows-x64-setup.exe) |
+| 🐧 Linux (Debian/Ubuntu) | [`gtfs-guru-linux-amd64.deb`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-linux-amd64.deb) |
+| 🐧 Linux (portable) | [`gtfs-guru-linux-amd64.AppImage`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-linux-amd64.AppImage) |
 
-Download the CLI for your platform from the
-[latest release](https://github.com/abasis-ltd/gtfs.guru/releases/latest), or use
-the installer:
+Run the installer, launch the app, and drop your `gtfs.zip` onto the window.
+
+## Command-line tool
+
+### Installer script
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/abasis-ltd/gtfs.guru/main/scripts/install.sh | bash
@@ -29,14 +46,86 @@ curl -fsSL https://raw.githubusercontent.com/abasis-ltd/gtfs.guru/main/scripts/i
 iwr -useb https://raw.githubusercontent.com/abasis-ltd/gtfs.guru/main/scripts/install.ps1 | iex
 ```
 
-## Python Package
+Both scripts honour a few environment variables:
+
+| Variable | Effect |
+| --- | --- |
+| `INSTALL_DIR` | Install somewhere other than `~/.local/bin` |
+| `GTFS_GURU_LINUX_FLAVOR` | `gnu` or `musl` (x86_64 Linux only) |
+| `GTFS_GURU_VERSION` | Pin a release, e.g. `v1.0.0` |
+
+### Prebuilt archives
+
+| Platform | Download |
+| --- | --- |
+| macOS (arm64) | [`gtfs-guru-macos-arm64.tar.gz`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-macos-arm64.tar.gz) |
+| macOS (x86_64) | [`gtfs-guru-macos-x86_64.tar.gz`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-macos-x86_64.tar.gz) |
+| Linux (x86_64, glibc) | [`gtfs-guru-linux-x86_64.tar.gz`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-linux-x86_64.tar.gz) |
+| Linux (x86_64, musl) | [`gtfs-guru-linux-x86_64-musl.tar.gz`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-linux-x86_64-musl.tar.gz) |
+| Linux (arm64) | [`gtfs-guru-linux-aarch64.tar.gz`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-linux-aarch64.tar.gz) |
+| Windows (x64) | [`gtfs-guru-windows-x64.zip`](https://github.com/abasis-ltd/gtfs.guru/releases/latest/download/gtfs-guru-windows-x64.zip) |
+
+### From crates.io
+
+```bash
+cargo install gtfs-guru
+```
+
+## Python package
+
+Requires Python 3.8 or newer.
 
 ```bash
 pip install gtfs-guru
+```
 
-# From source
+```python
+import gtfs_guru
+
+report = gtfs_guru.validate("path/to/gtfs.zip")
+print(f"Valid: {report.is_valid}, notices: {len(report.notices)}")
+
+report.save_html("validation_report.html")
+report.save_json("report.json")
+```
+
+See the [Python API](python_api.md) reference for the full surface.
+
+To build the wheel from a checkout:
+
+```bash
 cd crates/gtfs_validator_python
 pip install maturin
 maturin build --release
 pip install target/wheels/gtfs_guru-*.whl
 ```
+
+## MCP server
+
+```bash
+cargo install gtfs-guru-mcp
+```
+
+Prebuilt `gtfs-guru-mcp` archives are attached to every
+[release](https://github.com/abasis-ltd/gtfs.guru/releases/latest) for Linux
+(x86_64, x86_64-musl, aarch64), macOS (x86_64, arm64, universal), and Windows
+(x64). The [LLM Guide](llm.md#mcp-server) covers client configuration, the
+exposed tools, and the HTTP transport.
+
+## From source (Rust)
+
+On Linux, install the [system dependencies](system-dependencies.md) first.
+
+```bash
+git clone https://github.com/abasis-ltd/gtfs.guru
+cd gtfs.guru
+cargo build --release
+```
+
+Binaries land in `target/release/`:
+
+- `gtfs-guru` — command-line tool
+- `gtfs-guru-web` — web API server
+- `gtfs-guru-mcp` — MCP server
+
+To build only the CLI: `cargo build --release -p gtfs-guru`.

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -86,11 +86,15 @@ absolute path to the binary.
 Tools:
 
 - `list_gtfs_feeds`: discover ZIP archives and unzipped feeds under the
-  configured `--allow-dir` roots. Optional `nameContains` filters by name,
-  case-insensitively.
+  configured `--allow-dir` roots, each with the absolute path the other tools
+  take — so an assistant asked about a feed by name never has to search the
+  filesystem. Optional `nameContains` filters by name, case-insensitively.
 - `validate_gtfs`
 - `explain_gtfs`
 - `get_notice_details`
+
+File access is confined to the `--allow-dir` roots, and the server never
+writes to a feed.
 
 Validation and explanation responses include exact grouped totals plus up to
 three concrete examples per code/severity group, including available file,
@@ -117,6 +121,13 @@ Connect to `http://127.0.0.1:3000/mcp` and send
 deployment, terminate TLS at a reverse proxy and add its public hostname with
 `--allowed-host`. Use `--allowed-origin` when browser clients have a known
 origin. `/healthz` does not require authentication.
+
+The HTTP transport defaults to 60 authenticated requests per rolling minute,
+four concurrent validations, and 64 KiB request bodies.
+
+After an in-browser validation, [gtfs.guru](https://gtfs.guru) also renders a
+local "What ChatGPT receives" preview built from the same report. It shows the
+MCP payload shape without uploading the feed or calling an AI provider.
 
 Common flags:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,6 +13,28 @@ gtfs-guru --input /path/to/gtfs.zip --output_base ./report
 gtfs-guru --url https://example.com/gtfs.zip --output_base ./report
 ```
 
+Add `--storage_directory /tmp/gtfs` to keep a downloaded feed around instead of
+re-fetching it.
+
+### Output files
+
+Written into `--output_base`:
+
+| File | Written |
+| --- | --- |
+| `report.json` | always (rename with `--validation_report_name`) |
+| `report.html` | always (rename with `--html_report_name`) |
+| `system_errors.json` | always (rename with `--system_errors_report_name`) |
+| the name given to `--sarif` | with `--sarif` |
+| `notice_schema.json` | with `--export_notices_schema` |
+
+`--sarif` takes a file name resolved inside `--output_base`. Badges are the
+exception: they go to the exact path you name — see
+[Status badges](#status-badges).
+
+With `--stdout`, the JSON report goes to standard output and no report files are
+written.
+
 ### CLI Options
 
 | Option | Short | Description |
@@ -33,7 +55,7 @@ gtfs-guru --url https://example.com/gtfs.zip --output_base ./report
 | `--validated-at <TIMESTAMP>` | | Override `validated_at` in report metadata |
 | `--threads <N>` | | Number recorded in report metadata; does not size the thread pool |
 | `--google_rules` | | Enable Google-specific rules |
-| `--sarif <FILE>` | | Write SARIF report for CI/CD |
+| `--sarif <NAME>` | | Write a SARIF report for CI/CD into `--output_base` |
 | `--fail-on <LEVEL>` | | `none` (default), `error`, or `warning`; exit 2 at that severity |
 | `--badge <PATH>` | | Write a shields.io endpoint descriptor for a README badge |
 | `--badge-svg <PATH>` | | Write a self-contained SVG badge |
@@ -52,6 +74,48 @@ supported field values, trims declared GTFS fields, and sorts `stop_times.txt`
 by trip and `stop_sequence`. `--fix-unsafe` can additionally delete rows whose
 foreign key references a missing parent. After writing the copy, the CLI
 validates it again and reports resolved, remaining, and introduced notices.
+
+Ambiguous values are deliberately left alone — `01-05-2026` (day-first or
+month-first?) and `1,500` (1.5 or 1500?) get no suggestion at all. See
+[Fixes](llm.md#fixes) for the notice-by-notice repair table and its safety
+levels.
+
+### Subcommands
+
+#### `diff` — compare two feed versions
+
+```bash
+gtfs-guru diff old.zip new.zip
+gtfs-guru diff old.zip new.zip --json diff.json --markdown diff.md --fail-on-new-errors
+```
+
+The diff covers agencies, routes, stops, route-level trip and frequency
+aggregates, and validation notice deltas. Under `--fail-on-new-errors` it exits
+`2` when the new feed adds error occurrences. `--no-validation` gives a faster
+structural-only comparison.
+
+#### `profile` and `explain` — deterministic feed facts
+
+```bash
+gtfs-guru profile -i feed.zip --date 2026-07-27 --pretty
+gtfs-guru explain -i feed.zip --date 2026-07-27
+gtfs-guru explain -i feed.zip --json --pretty
+```
+
+`profile` reports unique entity counts, route types, completeness facts, seven
+actual service dates with calendar exceptions applied, and exact grouped
+validation totals. `explain` is derived from nothing but that profile, so every
+statement can be checked and no feed is sent to an LLM provider.
+
+#### `spec-surface` — what this build answers for
+
+```bash
+gtfs-guru spec-surface --pretty
+```
+
+Prints the files, fields, enum values, and notice codes the build supports,
+along with the specification revision and canonical validator release it was
+checked against.
 
 ### Which standard a report answers for
 
@@ -134,22 +198,60 @@ and they work with `--stdout` too.
 
 [shields-endpoint]: https://shields.io/badges/endpoint-badge
 
-### GitHub Actions
+### Continuous integration
 
-The repository ships a composite action that installs the binary, runs it,
-uploads SARIF to code scanning, and fails the job on a bad feed:
+#### GitHub Actions
+
+The repository ships a composite action that installs a checksum-verified
+binary, runs it, uploads SARIF to code scanning, and fails the job on a bad
+feed:
 
 ```yaml
-- uses: actions/checkout@v4
-- uses: abasis-ltd/gtfs.guru/action@v1
-  with:
-    feed: feed.zip
-    fail-on: error
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # so SARIF reaches the Security tab
+    steps:
+      - uses: actions/checkout@v4
+      - uses: abasis-ltd/gtfs.guru/action@v1
+        with:
+          feed: feed.zip
+          fail-on: error
 ```
 
 See [`action/README.md`](https://github.com/abasis-ltd/gtfs.guru/blob/main/action/README.md)
-for every input, the outputs it
-sets, and the badge-publishing recipe.
+for every input, the outputs it sets, and the badge-publishing recipe.
+
+Or drive the CLI yourself:
+
+```yaml
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install gtfs-guru
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/abasis-ltd/gtfs.guru/main/scripts/install.sh | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Run validation
+        run: gtfs-guru -i feed.zip -o out --fail-on error
+```
+
+#### GitLab CI
+
+```yaml
+validate:
+  image: ubuntu:22.04
+  before_script:
+    - apt-get update && apt-get install -y ca-certificates curl
+    - curl -fsSL https://raw.githubusercontent.com/abasis-ltd/gtfs.guru/main/scripts/install.sh | bash
+    - export PATH="$HOME/.local/bin:$PATH"
+  script:
+    - gtfs-guru -i feed.zip -o out --fail-on error
+```
 
 ## Web API
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
   - Installation: installation.md
   - System Dependencies: system-dependencies.md
   - Usage: usage.md
+  - Benchmarks: benchmarks.md
   - LLM Guide: llm.md
   - Python API: python_api.md
   - Validation Rules: rules.md


### PR DESCRIPTION
[The GTF-30 issue on Linear](https://linear.app/abasis/issue/GTF-30/to-make-readmemd-more-concise-and-readable)

The changelog:
 - What moved where:
```
┌──────────────────────────────────┬──────────────────────────┬────────────────────────────────────────┐
│           From README            │            To            │               Why there                │
├──────────────────────────────────┼──────────────────────────┼────────────────────────────────────────┤
│ Per-platform download matrices   │                          │ The page already existed and only had  │
│ (desktop + CLI archives),        │ docs/installation.md     │ 3 of 10 download paths                 │
│ installer env vars, versions     │                          │                                        │
├──────────────────────────────────┼──────────────────────────┼────────────────────────────────────────┤
│ Output files, diff / profile /   │                          │ Subcommands were documented nowhere on │
│ explain / spec-surface, GitHub   │ docs/usage.md            │  the site before                       │
│ Actions ×2 + GitLab CI           │                          │                                        │
├──────────────────────────────────┼──────────────────────────┼────────────────────────────────────────┤
│ Benchmark table, setup,          │ new docs/benchmarks.md   │ docs/agents/benchmarks.md is           │
│ reproduce commands               │ (added to nav)           │ repo-facing maintenance, excluded from │
│                                  │                          │ the site                               │
├──────────────────────────────────┼──────────────────────────┼────────────────────────────────────────┤
│ MCP HTTP limits, "What ChatGPT   │ docs/llm.md              │ 80% was already duplicated there       │
│ receives" preview                │                          │                                        │
├──────────────────────────────────┼──────────────────────────┼────────────────────────────────────────┤
│ Crate graph + crate list         │ CONTRIBUTING.md          │ Contributor material, and it replaced  │
│                                  │                          │ a thinner 3-bullet version             │
└──────────────────────────────────┴──────────────────────────┴────────────────────────────────────────┘
```
 - The `--export-notices-schema` argument mentioned in `README.md` doesn't exist – it has been replaced with `--export_notices_schema` in `docs/usage.md`.
 - Fixed the incosistency of documenting the `--sarif ` argument in `README.md` and `docs/usage.md`.
 - The mermaid graph used to wrongly claim the `MCP` crate's dependency on the `report` crate, plus the `profile` crate added.
- Centered header block — logo, tagline, badges, and three action links. The repo had two unused 1024px logos; the mark now earns its place. Its blue/teal lines read on both GitHub themes.
- Dropped decorative heading emoji (🌟 📌 📥 ⚡ 📂 🤝 📄). Cleaner anchors, calmer TOC. Kept the two that carry meaning (🐘/🪶). 
- Added GitHub alert for the MobilityData attribution instead of a bare blockquote.
- Left-aligned the comparison table. Centered cells with sentence-length content ("JVM startup + Java pipeline") looked ragged; the column had no header label at all.
- One documentation index table so every guide is one click from the top – previously `python_api.md`, `rules.md`, and `wasm.md` were unreachable from the README.
- No HTML tables – fenced code inside table cells is not rendered consistently by different engines including GitHub, while plain bold labels + code blocks render identically everywhere.
- Security and Code of Conduct now linked – both files existed, neither was referenced.
- `docs/installation.md` now has a navigation table in the beginning, as well as downloads that are now in tables (instead of lists) as well.