### PR TITLE
Implementation of GTF-32: skip the desktop crate in default workspace builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,11 +43,13 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      # --workspace is explicit: the manifest sets default-members to exclude
+      # the Tauri desktop crate for local builds, and CI must still cover it.
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Run tests
-        run: cargo test --all-features
+        run: cargo test --workspace --all-features
 
   wasm:
     name: WASM Build & Test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,9 @@ See `docs/system-dependencies.md` for the package list.
 
 ## Essential Commands
 
-- `cargo build` (workspace build)
+- `cargo build` (all crates except the Tauri desktop one, which `default-members`
+  excludes; it costs ~4 GB of debug artifacts and the webkit2gtk tree)
+- `cargo build -p gtfs-guru-gui` (desktop crate, when you are working on it)
 - `cargo build --release -p gtfs-guru` (CLI binary)
 - `cargo run --release -p gtfs-guru-web` (local API server)
 - `cargo test` or `cargo test -p gtfs-guru-core`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,21 @@ members = [
   "crates/gtfs_validator_python",
   "crates/gtfs_validator_wasm",
 ]
+# A bare `cargo build`/`cargo test` skips the Tauri desktop crate: it pulls the
+# whole webkit2gtk tree and leaves ~4 GB of debug artifacts behind, which is a
+# poor trade for a routine edit-test loop. CI and the pre-PR `--all`/`--workspace`
+# runs still cover it; build it directly with `-p gtfs-guru-gui`.
+default-members = [
+  "crates/gtfs_model",
+  "crates/gtfs_validator_core",
+  "crates/gtfs_validator_report",
+  "crates/gtfs_validator_profile",
+  "crates/gtfs_validator_cli",
+  "crates/gtfs_validator_mcp",
+  "crates/gtfs_validator_web",
+  "crates/gtfs_validator_python",
+  "crates/gtfs_validator_wasm",
+]
 resolver = "2"
 
 [workspace.package]

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -4,10 +4,14 @@ set -e
 echo "Running formatting check..."
 cargo fmt --all -- --check
 
+# --workspace is explicit for the same reason it is in .github/workflows/rust.yml:
+# the manifest sets default-members to exclude the Tauri desktop crate, and a
+# bare invocation respects that. This script is the pre-PR gate, so leaving it
+# bare would stop it covering the crate CI still builds.
 echo "Running Clippy..."
-cargo clippy --all-targets --all-features
+cargo clippy --workspace --all-targets --all-features
 
 echo "Running tests..."
-cargo test --all-features
+cargo test --workspace --all-features
 
 echo "All checks passed!"


### PR DESCRIPTION
[The GTF-32 issue on Linear](https://linear.app/abasis/issue/GTF-32/skip-the-desktop-crate-in-default-workspace-builds)

Don't merge this PR without merging PR #41 (implementation of GTF-31), because `.github/workflows/rust.yml` ran bare `cargo clippy` and `cargo test`:

```yaml
run: cargo clippy --all-targets --all-features -- -D warnings
run: cargo test --all-features
```

Bare invocations respect `default-members`. So `default-members` on its own
would have silently stopped testing the desktop crate in CI – a coverage
regression that no test failure would reveal. Both lines therefore gain an
explicit `--workspace`:

```yaml
run: cargo clippy --workspace --all-targets --all-features -- -D warnings
run: cargo test --workspace --all-features
```

Testing:
- `cargo metadata` confirms `default-members` resolves to 9 crates with exactly
  `gtfs-guru-gui` excluded
- full `cargo build` succeeds in 37.8s and produces no `gui`/`desktop` artifacts
- `cargo test -p gtfs-guru-core --lib` → 383 passed, 0 failed

This is the more opinionated of the two build PRs, since it changes what a bare `cargo test` means for every contributor. Happy to drop it and keep only #41 if you'd rather not shift that default.
