### PR TITLE
GTF-36: stop blaming the feed for a broken in-browser validator

### DIFF
--- a/crates/gtfs_validator_wasm/js/worker-mt.js
+++ b/crates/gtfs_validator_wasm/js/worker-mt.js
@@ -17,22 +17,25 @@ import init, {
   initThreadPool,
 } from './gtfs_guru_wasm.js';
 
-let initialized = false;
+let initializationPromise;
 
 // Cap the pool: beyond ~8 workers the marginal gain fades while per-thread
 // stack memory keeps growing, which matters for large feeds in wasm32.
 const MAX_THREADS = 8;
 
-async function ensureInitialized() {
-  if (initialized) return;
-  await init();
-  const threads = Math.max(
-    1,
-    Math.min(MAX_THREADS, self.navigator?.hardwareConcurrency || 4),
-  );
-  // Must run before any rayon parallel iterator, or the first one panics.
-  await initThreadPool(threads);
-  initialized = true;
+function ensureInitialized() {
+  if (!initializationPromise) {
+    initializationPromise = (async () => {
+      await init();
+      const threads = Math.max(
+        1,
+        Math.min(MAX_THREADS, self.navigator?.hardwareConcurrency || 4),
+      );
+      // Must run before any rayon parallel iterator, or the first one panics.
+      await initThreadPool(threads);
+    })();
+  }
+  return initializationPromise;
 }
 
 self.onmessage = async (event) => {
@@ -113,6 +116,13 @@ self.onmessage = async (event) => {
   }
 };
 
-// Signal that the worker is ready (module loaded). Note: the thread pool is
-// initialized lazily on the first 'validate' message, not here.
-self.postMessage({ type: 'ready' });
+// Initialize eagerly and only claim readiness once the module and its rayon
+// pool can actually validate. Announcing readiness at module load hid every
+// startup failure until the first feed arrived, where a dead worker is
+// indistinguishable from one that ran out of memory on a large feed.
+ensureInitialized()
+  .then(() => self.postMessage({ type: 'ready', payload: { runtime: 'multi-threaded' } }))
+  .catch((error) => self.postMessage({
+    type: 'error',
+    payload: error instanceof Error ? error.message : String(error),
+  }));

--- a/scripts/check_deployed_site.py
+++ b/scripts/check_deployed_site.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Fail when the deployed site is not serving the browser validator in this tree.
+
+The website is deployed by hand (`scripts/deploy-website.sh`), so the live
+files can silently fall behind the repository. When that happened, the site
+kept serving an old `script.js` next to a newer `pkg/`, the worker's module
+import 404'd, and every feed - down to nine bytes - was reported to users as
+"too large to validate in the browser". Nothing in CI noticed, because the
+repository itself was fine.
+
+This compares the bytes actually served with the bytes in this working tree for
+the assets the in-browser validator needs, and reports anything missing or
+stale. Run it after a deploy, or any time the site misbehaves:
+
+    python3 scripts/check_deployed_site.py                 # https://gtfs.guru
+    python3 scripts/check_deployed_site.py --base-url http://localhost:8901
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+# Everything the browser needs to load and run a validation. A stale or missing
+# file in this set breaks validation for every visitor and every feed size, so
+# each one is a deploy failure rather than a warning.
+CRITICAL_ASSETS = (
+    "script.js",
+    "style.css",
+    "pkg/worker.js",
+    "pkg/gtfs_guru_wasm.js",
+    "pkg/gtfs_guru_wasm_bg.wasm",
+    "pkg-mt/worker-mt.js",
+    "pkg-mt/gtfs_guru_wasm.js",
+    "pkg-mt/gtfs_guru_wasm_bg.wasm",
+    "pkg-mt/snippets/wasm-bindgen-rayon-38edf6e439f6d70d/src/workerHelpers.no-bundler.js",
+    "demo/gtfs-guru-demo.zip",
+)
+
+# The multithreaded tier only engages on a cross-origin-isolated page. Without
+# these the site still validates, just single-threaded, so they are reported
+# separately from a hard failure.
+ISOLATION_HEADERS = {
+    "cross-origin-opener-policy": "same-origin",
+    "cross-origin-embedder-policy": "require-corp",
+}
+
+
+def digest(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def fetch(url: str, timeout: float) -> tuple[int, bytes, dict[str, str]]:
+    request = urllib.request.Request(url, headers={"User-Agent": "gtfs-guru-deploy-check"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            headers = {k.lower(): v for k, v in response.headers.items()}
+            return response.status, response.read(), headers
+    except urllib.error.HTTPError as error:
+        return error.code, b"", {}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="https://gtfs.guru")
+    parser.add_argument(
+        "--website-root",
+        type=pathlib.Path,
+        default=pathlib.Path(__file__).resolve().parent.parent / "website",
+    )
+    parser.add_argument("--timeout", type=float, default=30.0)
+    args = parser.parse_args()
+
+    base = args.base_url.rstrip("/")
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    status, _, headers = fetch(f"{base}/", args.timeout)
+    if status != 200:
+        print(f"::error::{base}/ returned HTTP {status}")
+        return 1
+
+    for header, expected in ISOLATION_HEADERS.items():
+        actual = headers.get(header)
+        if actual != expected:
+            warnings.append(
+                f"{header}: {actual or 'absent'} (expected {expected}) — "
+                "the multithreaded validator tier will stay disabled"
+            )
+
+    for asset in CRITICAL_ASSETS:
+        local_path = args.website_root / asset
+        if not local_path.exists():
+            failures.append(f"{asset}: missing from {args.website_root} — run scripts/build-wasm.sh")
+            continue
+
+        status, payload, _ = fetch(f"{base}/{asset}", args.timeout)
+        if status != 200:
+            failures.append(f"{asset}: HTTP {status} — not deployed")
+            continue
+
+        served, local = digest(payload), digest(local_path.read_bytes())
+        if served != local:
+            failures.append(
+                f"{asset}: deployed {len(payload)} bytes ({served[:12]}) "
+                f"but this tree has {local_path.stat().st_size} bytes ({local[:12]}) — stale deploy"
+            )
+
+    for warning in warnings:
+        print(f"::warning::{warning}")
+    for failure in failures:
+        print(f"::error::{failure}")
+
+    if failures:
+        print(
+            f"\n{len(failures)} problem(s) with {base}. "
+            "Redeploy with: ./scripts/deploy-website.sh <server>",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"{base} is serving the {len(CRITICAL_ASSETS)} critical assets from this tree.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/deploy-website.sh
+++ b/scripts/deploy-website.sh
@@ -50,5 +50,16 @@ rsync -az \
 ssh "$SERVER" "rm -f -- ~/gtfs-guru-web/Dockerfile ~/gtfs-guru-web/nginx.conf"
 
 log_info "Website files copied successfully!"
+
+# 2. Confirm the live site is really serving what we just pushed. rsync runs
+# without --delete and the deploy is manual, so "it copied without an error" is
+# not evidence that the browser validator works: a stale script.js next to a
+# fresh pkg/ is exactly how every feed came to be reported as "too large".
+log_step "Verifying the deployed site..."
+if ! python3 "$SCRIPT_DIR/check_deployed_site.py" --base-url "${VERIFY_URL:-https://gtfs.guru}"; then
+    log_error "The live site is not serving these files. The deploy is not finished."
+    exit 1
+fi
+
 echo ""
-echo "✅ Deployment complete! Refresh your browser to see changes."
+echo "✅ Deployment complete and verified! Refresh your browser to see changes."

--- a/scripts/serve_website.py
+++ b/scripts/serve_website.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Serve website/ locally with the headers production sends.
+
+`python3 -m http.server` omits COOP/COEP, so `crossOriginIsolated` is false and
+the local site silently never exercises the multithreaded worker tier that real
+visitors get. Bugs that only live in that tier stay invisible until deploy.
+
+    python3 scripts/serve_website.py [port]
+"""
+
+from __future__ import annotations
+
+import functools
+import http.server
+import pathlib
+import socketserver
+import sys
+
+
+class IsolatedHandler(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self) -> None:
+        # Required for SharedArrayBuffer, and so for wasm threads. Mirrors
+        # website/nginx.conf and website/_headers.
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        # Local iteration should never be served a cached worker or wasm blob.
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+    def log_message(self, fmt: str, *args) -> None:
+        if not self.path.startswith("/notices/"):
+            super().log_message(fmt, *args)
+
+
+def main() -> int:
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8901
+    root = pathlib.Path(__file__).resolve().parent.parent / "website"
+    socketserver.TCPServer.allow_reuse_address = True
+    handler = functools.partial(IsolatedHandler, directory=str(root))
+    with socketserver.TCPServer(("127.0.0.1", port), handler) as httpd:
+        print(f"Serving {root} at http://localhost:{port} (cross-origin isolated)", flush=True)
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/website/pkg-mt/worker-mt.js
+++ b/website/pkg-mt/worker-mt.js
@@ -17,22 +17,25 @@ import init, {
   initThreadPool,
 } from './gtfs_guru_wasm.js';
 
-let initialized = false;
+let initializationPromise;
 
 // Cap the pool: beyond ~8 workers the marginal gain fades while per-thread
 // stack memory keeps growing, which matters for large feeds in wasm32.
 const MAX_THREADS = 8;
 
-async function ensureInitialized() {
-  if (initialized) return;
-  await init();
-  const threads = Math.max(
-    1,
-    Math.min(MAX_THREADS, self.navigator?.hardwareConcurrency || 4),
-  );
-  // Must run before any rayon parallel iterator, or the first one panics.
-  await initThreadPool(threads);
-  initialized = true;
+function ensureInitialized() {
+  if (!initializationPromise) {
+    initializationPromise = (async () => {
+      await init();
+      const threads = Math.max(
+        1,
+        Math.min(MAX_THREADS, self.navigator?.hardwareConcurrency || 4),
+      );
+      // Must run before any rayon parallel iterator, or the first one panics.
+      await initThreadPool(threads);
+    })();
+  }
+  return initializationPromise;
 }
 
 self.onmessage = async (event) => {
@@ -113,6 +116,13 @@ self.onmessage = async (event) => {
   }
 };
 
-// Signal that the worker is ready (module loaded). Note: the thread pool is
-// initialized lazily on the first 'validate' message, not here.
-self.postMessage({ type: 'ready' });
+// Initialize eagerly and only claim readiness once the module and its rayon
+// pool can actually validate. Announcing readiness at module load hid every
+// startup failure until the first feed arrived, where a dead worker is
+// indistinguishable from one that ran out of memory on a large feed.
+ensureInitialized()
+  .then(() => self.postMessage({ type: 'ready', payload: { runtime: 'multi-threaded' } }))
+  .catch((error) => self.postMessage({
+    type: 'error',
+    payload: error instanceof Error ? error.message : String(error),
+  }));

--- a/website/script.js
+++ b/website/script.js
@@ -19,6 +19,18 @@
 const MAX_FILE_SIZE_BYTES = 150 * 1024 * 1024;
 const MAX_UNCOMPRESSED_BYTES = 700 * 1024 * 1024;
 
+// A worker that dies mid-run is only credibly out of memory once the feed is
+// substantial: wasm32 does not exhaust its heap on a few megabytes. Below this
+// unpacked size a dead worker is a broken build, a failed module import, or a
+// panic, and is reported as such instead of being blamed on the feed's size.
+const OOM_PLAUSIBLE_RAW_BYTES = 64 * 1024 * 1024;
+
+// postMessage transfers (and detaches) the feed buffer, so retrying a crashed
+// run needs a second copy. Keep one for feeds small enough that the duplicate
+// costs nothing; larger feeds are exactly the ones where doubling memory would
+// cause the failure we are trying to survive.
+const RETRY_COPY_LIMIT_BYTES = 32 * 1024 * 1024;
+
 // Multithreaded (wasm threads) validation: ~5x faster on large feeds. Only
 // engages on cross-origin-isolated pages (COOP/COEP headers set server-side);
 // everything else falls back to the single-threaded worker automatically.
@@ -128,13 +140,53 @@ function getValidatorWorker() {
             rejectReady(new Error('__WORKER_UNAVAILABLE__'));
             if (p) p.reject(new Error('__WORKER_UNAVAILABLE__'));
         } else {
-            // It was running and died — almost always a hard OOM on a big feed.
-            if (p) p.reject(new Error('__OOM__'));
+            // It was running and died. A large feed really can exhaust the wasm
+            // heap, but so can a missing module import or a panic on a
+            // three-line feed, and calling all of those "too large" sends
+            // people hunting a size problem they do not have. Decide from the
+            // size actually submitted, and keep what the browser reported.
+            const detail = describeWorkerError(e, tier.name);
+            const outOfMemory = p ? looksLikeMemoryExhaustion(p) : false;
+            console.error(`Validator worker stopped (${detail})`);
+            if (!outOfMemory) {
+                // Not a memory problem, so this tier is broken rather than
+                // overloaded: step down to the next one, and once they are
+                // exhausted let validation fall back to the main thread.
+                if (workerTierIndex < WORKER_TIERS.length - 1) {
+                    workerTierIndex++;
+                } else {
+                    workerUsable = false;
+                }
+            }
+            if (p) {
+                const err = new Error(outOfMemory ? '__OOM__' : '__WORKER_CRASHED__');
+                err.detail = detail;
+                p.reject(err);
+            }
         }
     };
 
     validatorWorker = worker;
     return worker;
+}
+
+// What the browser could tell us about a worker that died. ErrorEvent from a
+// module worker is often bare (a failed import reports nothing but the event),
+// so say that explicitly rather than rendering "undefined".
+function describeWorkerError(event, tierName) {
+    const parts = [];
+    if (event && event.message) parts.push(event.message);
+    if (event && event.filename) parts.push(`${event.filename}:${event.lineno || 0}`);
+    return `${tierName} tier: ${parts.join(' ') ||
+        'no detail from the browser, which usually means the worker module or its WASM failed to load'}`;
+}
+
+// Could this run plausibly have exhausted the wasm heap?
+function looksLikeMemoryExhaustion({ rawBytes, zipBytes }) {
+    // Fall back to a conservative expansion factor when the central directory
+    // could not be read, so an unreadable zip is never called "too large".
+    const unpacked = typeof rawBytes === 'number' ? rawBytes : (zipBytes || 0) * 5;
+    return unpacked > OOM_PLAUSIBLE_RAW_BYTES;
 }
 
 // ---- Stops index for the error map ----
@@ -535,9 +587,13 @@ async function validateInWorker(arrayBuffer, dateStr) {
         workerReadyPromise,
         new Promise((_, rej) => setTimeout(() => rej(new Error('__WORKER_UNAVAILABLE__')), 10000)),
     ]);
+    // Read the sizes while the buffer is still ours: if the worker dies, they
+    // are the only evidence left for telling memory exhaustion from a crash.
+    const zipBytes = arrayBuffer.byteLength;
+    const rawBytes = sumUncompressedBytes(arrayBuffer);
     return new Promise((resolve, reject) => {
         const id = nextMsgId++;
-        pendingValidation = { id, resolve, reject };
+        pendingValidation = { id, resolve, reject, zipBytes, rawBytes };
         // Transfer (not copy) the ArrayBuffer — feeds can be up to 150 MB.
         validatorWorker.postMessage(
             { type: 'validate', id, payload: { zipBytes: arrayBuffer, date: dateStr } },
@@ -569,9 +625,14 @@ async function diffInWorker(oldArrayBuffer, newArrayBuffer, dateStr) {
         new Promise((_, reject) =>
             setTimeout(() => reject(new Error('__WORKER_UNAVAILABLE__')), 10000)),
     ]);
+    // Both feeds are resident at once, so the memory question is their sum.
+    const zipBytes = oldArrayBuffer.byteLength + newArrayBuffer.byteLength;
+    const oldRaw = sumUncompressedBytes(oldArrayBuffer);
+    const newRaw = sumUncompressedBytes(newArrayBuffer);
+    const rawBytes = oldRaw === null || newRaw === null ? null : oldRaw + newRaw;
     return new Promise((resolve, reject) => {
         const id = nextMsgId++;
-        pendingValidation = { id, resolve, reject };
+        pendingValidation = { id, resolve, reject, zipBytes, rawBytes };
         validatorWorker.postMessage(
             {
                 type: 'diff',
@@ -614,15 +675,26 @@ async function diffFeeds(oldArrayBuffer, newArrayBuffer, dateStr) {
     return diffOnMainThread(oldArrayBuffer, newArrayBuffer, dateStr);
 }
 
-// Validate via the worker, transparently falling back to the main thread if the
-// worker can't be loaded. A mid-validation OOM ('__OOM__') is NOT retried.
+// Validate via the worker, transparently falling back to the next tier and
+// finally to the main thread if the worker can't be loaded or dies on a feed
+// too small to have exhausted memory. A genuine OOM ('__OOM__') is NOT retried:
+// the same feed would only exhaust the heap again.
 async function validateFeed(arrayBuffer, dateStr) {
     if (workerUsable) {
+        const retryCopy = arrayBuffer.byteLength <= RETRY_COPY_LIMIT_BYTES
+            ? arrayBuffer.slice(0)
+            : null;
         try {
             return await validateInWorker(arrayBuffer, dateStr);
         } catch (err) {
-            if (err && err.message === '__WORKER_UNAVAILABLE__') {
+            const code = err && err.message;
+            if (code === '__WORKER_UNAVAILABLE__') {
                 // fall through to main-thread validation with the intact buffer
+            } else if (code === '__WORKER_CRASHED__' && retryCopy) {
+                // The tier was stepped down (or workers were given up on) as
+                // the worker died, so this retry lands somewhere else.
+                console.warn(`Retrying validation after a worker crash — ${err.detail}`);
+                return validateFeed(retryCopy, dateStr);
             } else {
                 throw err;
             }
@@ -1209,7 +1281,10 @@ Download the .zip and drop it here instead; validation still runs locally in you
             console.error('Feed comparison error:', err);
             const message = err?.message === '__OOM__'
                 ? 'These feeds were too large to compare in this browser. Use the desktop app or CLI.'
-                : (err?.message || 'Could not compare these feeds.');
+                : err?.message === '__WORKER_CRASHED__'
+                    ? 'The in-browser comparison failed to run on this page — this is a problem with the site, ' +
+                      `not with your feeds. Reload to try again, or use the desktop app or CLI. Details: ${err.detail}`
+                    : (err?.message || 'Could not compare these feeds.');
             showValidationError(message);
         }
     }
@@ -1506,6 +1581,14 @@ Download the .zip and drop it here instead; validation still runs locally in you
                 showValidationError(
                     "This feed was too large to validate in the browser on this device. " +
                     "Try a Chrome/Firefox-based desktop browser, or use the free desktop app or CLI for large feeds."
+                );
+                return;
+            }
+            if (err && err.message === '__WORKER_CRASHED__') {
+                showValidationError(
+                    "The in-browser validator failed to run on this page — this is a problem with the site, " +
+                    "not with your feed. Reload to try again, or use the free desktop app or CLI. " +
+                    `Details for a bug report: ${err.detail}`
                 );
                 return;
             }


### PR DESCRIPTION
Fixes GTF-36 — https://linear.app/abasis/issue/GTF-36

## What was actually wrong

The site rejected every feed, down to nine bytes, with *"This feed was too large to validate in the browser on this device."*

The cause is not the size gate. **gtfs.guru is serving a stale website**: an old `script.js` next to a newer `pkg/`, so the worker's module import 404s and the worker dies. That old `script.js` treated any worker-level error as an out-of-memory kill, which is how a tiny feed came to be called too large. Reproduced live with a 9-byte file; the console shows `404` followed by `Error: __OOM__ at validatorWorker.onerror (script.js:51)`.

Redeploying is a separate, manual step (`./scripts/deploy-website.sh <server>`) and is not part of this PR. What is in scope is that the code should not have lied about it, and that a stale deploy should not be able to go unnoticed again.

## Changes

**Report the real failure**

- A dead worker is only called an OOM when the feed could plausibly have exhausted the wasm heap. Sizes are read before `postMessage` transfers the buffer away, because afterwards they are the only evidence left. Anything smaller is reported as a site failure, carrying the browser's own error text for a bug report.
- A worker that dies for a reason other than memory steps down to the next tier, and small feeds keep a copy so the retry has something to run. A broken multithreaded build now degrades to single-threaded and then to the main thread instead of dead-ending.
- The multithreaded worker announces `ready` only once its module and rayon pool are up. It used to post `ready` at module load, so a startup failure stayed hidden until the first feed arrived and looked like an OOM.

**Guards**

- `scripts/check_deployed_site.py` compares the bytes the live site serves against this tree for the assets the validator needs. Run against gtfs.guru today it reports all ten as stale or missing. `deploy-website.sh` now fails on it, so a copy that did not take can no longer look like a finished deploy.
- `scripts/serve_website.py` serves `website/` with the COOP/COEP headers production sends. `python3 -m http.server` does not, so local runs never exercised the multithreaded tier real visitors get.

## Verification

- Reproduced the bug against production, and confirmed the diagnosis from the console and from asset hashes.
- Locally (cross-origin isolated): a normal feed validates on the mt tier.
- With the mt worker made to die mid-run: the tier steps down and validation still succeeds, logging the real cause instead of a size claim.
- With both workers made to die: validation still succeeds on the main thread.
- `check_deployed_site.py` passes against a local server and fails, itemised, against gtfs.guru.
- `check_repository_artifacts.py`, `check_website_links.py`, `build_demo_feed.py --check` all pass.

## Follow-up, not in this PR

`deploy-website.sh` rsyncs without `--delete`, so files removed from the repo live on the server forever. Worth adding, but it deletes on a host I cannot inspect, so it should be a deliberate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)